### PR TITLE
set the default docker image version to 20190213T123836

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20190208T112604
+      DOCKER_IMAGE_VERSION: 20190213T123836
       TC_WORKER_CONF: gecko-t-ap
   mozilla-unittest-p2:
     device_group_name: pixel2-unit
@@ -80,7 +80,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
       TC_WORKER_TYPE: gecko-t-ap-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190208T112604
+      DOCKER_IMAGE_VERSION: 20190213T123836
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
the test of the tooltool cache-less docker image was a success, promote to default