### PR TITLE
g-w: fix client_id and worker_type

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -68,8 +68,8 @@ projects:
     framework_name: mozilla-usb
     description: Mozilla Unit tests for Pixel2 (using generic-worker)
     additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-p2
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-p2
+      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-gw-unit-p2
+      TC_WORKER_TYPE: gecko-t-bitbar-unit-p2
       DOCKER_IMAGE_VERSION: 20190325T160701
   mozilla-gw-perftest-p2:
     device_group_name: pixel2-perf-2
@@ -77,8 +77,8 @@ projects:
     framework_name: mozilla-usb
     description: Mozilla Performance tests for Pixel2 (using generic-worker)
     additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-p2
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-p2
+      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-gw-perf-p2
+      TC_WORKER_TYPE: gecko-t-bitbar-perf-p2
       DOCKER_IMAGE_VERSION: 20190325T160701
   mozilla-gw-perftest-g5:
     device_group_name: motog5-perf-2
@@ -86,8 +86,8 @@ projects:
     framework_name: mozilla-usb
     description: Mozilla Performance tests for MotoG5 (using generic-worker)
     additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-g5
+      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-gw-perf-g5
+      TC_WORKER_TYPE: gecko-t-bitbar-perf-g5
       DOCKER_IMAGE_VERSION: 20190325T160701
   mozilla-gw-batttest-p2:
     device_group_name: pixel2-batt-2
@@ -95,8 +95,8 @@ projects:
     framework_name: mozilla-tcp
     description: Mozilla Battery tests for Pixel2 (using generic-worker)
     additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-p2
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-p2
+      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-gw-batt-p2
+      TC_WORKER_TYPE: gecko-t-bitbar-batt-p2
       DOCKER_IMAGE_VERSION: 20190325T160701
   mozilla-gw-batttest-g5:
     device_group_name: motog5-batt-2
@@ -104,8 +104,8 @@ projects:
     framework_name: mozilla-tcp
     description: Mozilla Battery tests for MotoG5 (using generic-worker)
     additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-g5
+      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-gw-batt-g5
+      TC_WORKER_TYPE: gecko-t-bitbar-batt-g5
       DOCKER_IMAGE_VERSION: 20190325T160701
   mozilla-gw-unittest-g5:
     device_group_name: motog5-unit-2
@@ -113,8 +113,8 @@ projects:
     framework_name: mozilla-usb
     description: Mozilla Unit tests for MotoG5 (using generic-worker)
     additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-g5
+      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-gw-unit-g5
+      TC_WORKER_TYPE: gecko-t-bitbar-unit-g5
       DOCKER_IMAGE_VERSION: 20190325T160701
   # used for building new docker images
   mozilla-docker-build:


### PR DESCRIPTION
I had them switched.

Tested on autophone1.

```
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]: Traceback (most recent call last):
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 170, in <module>
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:     main()
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 167, in main
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:     args.func(args)
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 56, in test_run_manager
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:     configuration.configure(bitbar_configpath, filespath=args.files)
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/configuration.py", line 71, in configure
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:     configure_projects()
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/configuration.py", line 203, in configure_projects
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:     additional_parameters['TASKCLUSTER_ACCESS_TOKEN'] = os.environ[taskcluster_access_token_name]
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/lib64/python2.7/UserDict.py", line 40, in __getitem__
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]:     raise KeyError(key)
Apr 04 11:39:46 autophone-1.qa.mtv2.mozilla.com bash[4669]: KeyError: 'gecko_t_bitbar_gw_perf_p2'
```

