### PR TITLE
use new g-w image with PATH fix

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -122,21 +122,21 @@ projects:
     device_model: motog4
     framework_name: Docker image build
     description: Mozilla Docker image build
-    test_file: mozilla-docker-20190208T112604.zip
+    test_file: mozilla-docker-20190423T121205.zip
     application_file: aerickson-Testdroid.apk
     additional_parameters:
-      DOCKER_IMAGE_VERSION: 20190208T112604
+      DOCKER_IMAGE_VERSION: 20190423T121205
   # used for testing new docker images
-  mozilla-docker-image-test:
-    device_group_name: motog5-test
-    device_model: motog5
-    framework_name: mozilla-usb
-    description: Mozilla Docker image test
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
-      TC_WORKER_TYPE: gecko-t-ap-test-g5
-      # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190213T123836
+  #mozilla-docker-image-test:
+  #  device_group_name: motog5-test
+  #  device_model: motog5
+  #  framework_name: mozilla-usb
+  #  description: Mozilla Docker image test
+  #  additional_parameters:
+  #    TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
+  #    TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
+  #    # replace with version to test
+  #    DOCKER_IMAGE_VERSION: 20190423T121205
 device_groups:
   motog4-docker-builder:
     Docker Builder:

--- a/config/config.yml
+++ b/config/config.yml
@@ -70,7 +70,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-p2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-p2
-      DOCKER_IMAGE_VERSION: 20190408T165211
+      DOCKER_IMAGE_VERSION: 20190423T121205
   mozilla-gw-perftest-p2:
     device_group_name: pixel2-perf-2
     device_model: pixel2
@@ -79,7 +79,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-p2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-p2
-      DOCKER_IMAGE_VERSION: 20190408T165211
+      DOCKER_IMAGE_VERSION: 20190423T121205
   mozilla-gw-perftest-g5:
     device_group_name: motog5-perf-2
     device_model: motog5
@@ -88,7 +88,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-g5
-      DOCKER_IMAGE_VERSION: 20190408T165211
+      DOCKER_IMAGE_VERSION: 20190423T121205
   mozilla-gw-batttest-p2:
     device_group_name: pixel2-batt-2
     device_model: pixel2
@@ -97,7 +97,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-p2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-p2
-      DOCKER_IMAGE_VERSION: 20190408T165211
+      DOCKER_IMAGE_VERSION: 20190423T121205
   mozilla-gw-batttest-g5:
     device_group_name: motog5-batt-2
     device_model: motog5
@@ -106,7 +106,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-g5
-      DOCKER_IMAGE_VERSION: 20190408T165211
+      DOCKER_IMAGE_VERSION: 20190423T121205
   mozilla-gw-unittest-g5:
     device_group_name: motog5-unit-2
     device_model: motog5
@@ -115,7 +115,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-g5
-      DOCKER_IMAGE_VERSION: 20190408T165211
+      DOCKER_IMAGE_VERSION: 20190423T121205
   # used for building new docker images
   mozilla-docker-build:
     device_group_name: motog4-docker-builder


### PR DESCRIPTION
Image was built from https://github.com/bclary/mozilla-bitbar-docker/pull/6.