### PR TITLE
take secret params in secret.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ venv
 *~
 *.pyc
 *.egg-info
-
+secret.yml

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -50,13 +50,16 @@ def get_filespath():
     return FILESPATH
 
 
-def configure(bitbar_configpath, filespath=None):
+def configure(bitbar_configpath, secret_configpath, filespath=None):
     """Parse and load the configuration yaml file
     defining the Mozilla Bitbar test setup.
 
     :param bitbar_configpath: string path to the config.yml
                               containing the Mozilla Bitbar
                               configuration.
+    :param secret_configpath: string path to the secret.yml
+                              containing the Mozilla Bitbar
+                              secret configuration.
     :param filespath: string path to the files directory where
                       application and test files are kept.
     """
@@ -66,6 +69,12 @@ def configure(bitbar_configpath, filespath=None):
 
     with open(bitbar_configpath) as bitbar_configfile:
         CONFIG = yaml.load(bitbar_configfile.read())
+
+    if os.path.exists(secret_configpath):
+        with open(secret_configpath) as secret_configfile:
+            secret_yml = yaml.load(secret_configfile.read())
+        # merge with CONFIG
+        CONFIG = apply_dict_defaults(secret_yml, CONFIG)
 
     configure_device_groups()
     configure_projects()

--- a/mozilla_bitbar_devicepool/main.py
+++ b/mozilla_bitbar_devicepool/main.py
@@ -53,7 +53,12 @@ def test_run_manager(args):
     else:
         bitbar_configpath = args.bitbar_config
 
-    configuration.configure(bitbar_configpath, filespath=args.files)
+    if args.secret_config is None:
+        secret_configpath = os.path.join(modulepath, 'config', 'secret.yml')
+    else:
+        secret_configpath = args.secret_config
+
+    configuration.configure(bitbar_configpath, secret_configpath=secret_configpath, filespath=args.files)
 
     manager = TestRunManager(wait=args.wait,
                              delete_bitbar_tests=args.delete_bitbar_tests)
@@ -70,7 +75,12 @@ def run_test(args):
     else:
         bitbar_configpath = args.bitbar_config
 
-    configuration.configure(bitbar_configpath, filespath=args.files)
+    if args.secret_config is None:
+        secret_configpath = os.path.join(modulepath, 'config', 'secret.yml')
+    else:
+        secret_configpath = args.secret_config
+
+    configuration.configure(bitbar_configpath, secret_configpath=secret_configpath, filespath=args.files)
 
     run_test_for_project(args.project_name)
 
@@ -155,6 +165,8 @@ Terminate Now
                                       help="Run test for a project then exit.")
     subparser.add_argument("--bitbar-config",
                            help="Path to Bitbar yaml configuration file.")
+    subparser.add_argument("--secret-config",
+                           help="Path to Bitbar secret yaml configuration file.")
     subparser.add_argument("--project-name",
                            required=True,
                            help="Specify a project name for which to start a test.")


### PR DESCRIPTION
Adds a new yaml file (secrets.yml by default) that overrides the default config. The idea is that it is never committed to git.

Stackdriver logging can use an environment variable for credentials. This change allows us to pass the credential to Stackdriver and keep it secure.

Companion to https://github.com/bclary/mozilla-bitbar-docker/pull/7.