### PR TITLE
add new hosts

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -147,13 +147,38 @@ device_groups:
     motog5-04:
     motog5-05:
     motog5-06:
-  motog5-perf-2:
     motog5-07:
     motog5-09:
     motog5-10:
     motog5-11:
     motog5-12:
     motog5-13:
+    motog5-16:
+  motog5-perf-2:
+    motog5-17:
+    motog5-18:
+    motog5-19:
+    motog5-20:
+    motog5-21:
+    motog5-22:
+    motog5-23:
+    motog5-24:
+    motog5-25:
+    motog5-26:
+    motog5-27:
+    motog5-28:
+    motog5-29:
+    motog5-30:
+    motog5-31:
+    motog5-32:
+    motog5-33:
+    motog5-34:
+    motog5-35:
+    motog5-36:
+    motog5-37:
+    motog5-38:
+    motog5-39:
+    motog5-40:
   motog5-unit:
   motog5-unit-2:
   motog5-test:
@@ -192,13 +217,38 @@ device_groups:
     pixel2-25:
     pixel2-26:
     pixel2-27:
-  pixel2-perf-2:
     pixel2-28:
     pixel2-29:
     pixel2-30:
     pixel2-31:
     pixel2-32:
     pixel2-33:
+    pixel2-36:
+  pixel2-perf-2:
+    pixel2-37:
+    pixel2-38:
+    pixel2-39:
+    pixel2-40:
+    pixel2-41:
+    pixel2-42:
+    pixel2-43:
+    pixel2-44:
+    pixel2-45:
+    pixel2-46:
+    pixel2-47:
+    pixel2-48:
+    pixel2-49:
+    pixel2-50:
+    pixel2-51:
+    pixel2-52:
+    pixel2-53:
+    pixel2-54:
+    pixel2-55:
+    pixel2-56:
+    pixel2-57:
+    pixel2-58:
+    pixel2-59:
+    pixel2-60:
   pixel2-batt:
   pixel2-batt-2:
     pixel2-34:


### PR DESCRIPTION
Perf is where the queues are currently backed up. 

Are there concerns with adding this many new devices to perf queues?

```
motog5-batt: 0
motog5-perf: 13
motog5-unit: 0
pixel2-batt: 0
pixel2-perf: 16
pixel2-unit: 2
motog5-batt-2: 2
motog5-perf-2: 24
motog5-unit-2: 0
pixel2-batt-2: 2
pixel2-perf-2: 24
pixel2-unit-2: 16
```

current master:
```
motog5-batt: 0
motog5-perf: 6
motog5-unit: 0
pixel2-batt: 0
pixel2-perf: 9
pixel2-unit: 2
motog5-batt-2: 2
motog5-perf-2: 6
motog5-unit-2: 0
pixel2-batt-2: 2
pixel2-perf-2: 6
pixel2-unit-2: 16
```