### PR TITLE
use latest g-w image

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -70,7 +70,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-p2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-p2
-      DOCKER_IMAGE_VERSION: 20190423T121205
+      DOCKER_IMAGE_VERSION: 20190528T112747
   mozilla-gw-perftest-p2:
     device_group_name: pixel2-perf-2
     device_model: pixel2
@@ -79,7 +79,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-p2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-p2
-      DOCKER_IMAGE_VERSION: 20190423T121205
+      DOCKER_IMAGE_VERSION: 20190528T112747
   mozilla-gw-perftest-g5:
     device_group_name: motog5-perf-2
     device_model: motog5
@@ -88,7 +88,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-g5
-      DOCKER_IMAGE_VERSION: 20190423T121205
+      DOCKER_IMAGE_VERSION: 20190528T112747
   mozilla-gw-batttest-p2:
     device_group_name: pixel2-batt-2
     device_model: pixel2
@@ -97,7 +97,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-p2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-p2
-      DOCKER_IMAGE_VERSION: 20190423T121205
+      DOCKER_IMAGE_VERSION: 20190528T112747
   mozilla-gw-batttest-g5:
     device_group_name: motog5-batt-2
     device_model: motog5
@@ -106,7 +106,7 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-g5
-      DOCKER_IMAGE_VERSION: 20190423T121205
+      DOCKER_IMAGE_VERSION: 20190528T112747
   mozilla-gw-unittest-g5:
     device_group_name: motog5-unit-2
     device_model: motog5
@@ -115,17 +115,17 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-g5
-      DOCKER_IMAGE_VERSION: 20190423T121205
+      DOCKER_IMAGE_VERSION: 20190528T112747
   # used for building new docker images
   mozilla-docker-build:
     device_group_name: motog4-docker-builder
     device_model: motog4
     framework_name: Docker image build
     description: Mozilla Docker image build
-    test_file: mozilla-docker-20190423T121205.zip
+    test_file: mozilla-docker-20190528T112747.zip
     application_file: aerickson-Testdroid.apk
     additional_parameters:
-      DOCKER_IMAGE_VERSION: 20190423T121205
+      DOCKER_IMAGE_VERSION: 20190528T112747
   # used for testing new docker images
   #mozilla-docker-image-test:
   #  device_group_name: motog5-test
@@ -136,7 +136,7 @@ projects:
   #    TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
   #    TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
   #    # replace with version to test
-  #    DOCKER_IMAGE_VERSION: 20190423T121205
+  #    DOCKER_IMAGE_VERSION: 20190528T112747
 device_groups:
   motog4-docker-builder:
     Docker Builder:

--- a/config/config.yml
+++ b/config/config.yml
@@ -143,6 +143,7 @@ device_groups:
   motog5-perf:
     motog5-01:
     motog5-02:
+  motog5-perf-2:
     motog5-03:
     motog5-04:
     motog5-05:
@@ -154,7 +155,6 @@ device_groups:
     motog5-12:
     motog5-13:
     motog5-16:
-  motog5-perf-2:
     motog5-17:
     motog5-18:
     motog5-19:
@@ -210,6 +210,7 @@ device_groups:
   pixel2-perf:
     pixel2-19:
     pixel2-20:
+  pixel2-perf-2:
     pixel2-21:
     pixel2-22:
     pixel2-23:
@@ -224,7 +225,6 @@ device_groups:
     pixel2-32:
     pixel2-33:
     pixel2-36:
-  pixel2-perf-2:
     pixel2-37:
     pixel2-38:
     pixel2-39:


### PR DESCRIPTION
what's changed in this image version: https://github.com/bclary/mozilla-bitbar-docker/pull/7

device group report with this change's config:
```
motog5-batt: 0
motog5-perf: 2
motog5-unit: 0
pixel2-batt: 0
pixel2-perf: 2
pixel2-unit: 2
motog5-batt-2: 2
motog5-perf-2: 35
motog5-unit-2: 0
pixel2-batt-2: 2
pixel2-perf-2: 38
pixel2-unit-2: 16
```