### PR TITLE
fix yaml warning

### DIFF
--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -65,7 +65,7 @@ def configure(bitbar_configpath, filespath=None):
     FILESPATH=filespath
 
     with open(bitbar_configpath) as bitbar_configfile:
-        CONFIG = yaml.load(bitbar_configfile.read())
+        CONFIG = yaml.load(bitbar_configfile.read(), Loader=yaml.SafeLoader)
 
     configure_device_groups()
     configure_projects()


### PR DESCRIPTION
Happening with newer python versions.

```
May 30 16:53:46 bitbar-devicepool-0 bash[16669]: /home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/configuration.py:68: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
May 30 16:53:46 bitbar-devicepool-0 bash[16669]:   CONFIG = yaml.load(bitbar_configfile.read())
```

see https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation