### PR TITLE
move all devices to g-w pools

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -141,9 +141,9 @@ device_groups:
   motog4-docker-builder:
     Docker Builder:
   motog5-perf:
+  motog5-perf-2:
     motog5-01:
     motog5-02:
-  motog5-perf-2:
     motog5-03:
     motog5-04:
     motog5-05:
@@ -188,9 +188,9 @@ device_groups:
     motog5-08:
     motog5-15:
   pixel2-unit:
+  pixel2-unit-2:
     pixel2-01:
     pixel2-02:
-  pixel2-unit-2:
     pixel2-03:
     pixel2-04:
     pixel2-05:
@@ -208,9 +208,9 @@ device_groups:
     pixel2-17:
     pixel2-18:
   pixel2-perf:
+  pixel2-perf-2:
     pixel2-19:
     pixel2-20:
-  pixel2-perf-2:
     pixel2-21:
     pixel2-22:
     pixel2-23:

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -34,7 +34,7 @@ class DeviceGroupReport:
         for group in conf_yaml["device_groups"]:
             the_item = conf_yaml["device_groups"][group]
             # filter out the test queue and the builder job
-            if "-test" not in group and "-builder" not in group:
+            if "-builder" not in group:
                 if group.endswith("-2"):
                     self.gw_result_dict[group] = get_len(the_item)
                 else:


### PR DESCRIPTION
We haven't had any (non-accidental) jobs on the old pools for awhile.

device group report with this change:
```
motog5-batt: 0
motog5-perf: 0
motog5-test: 1
motog5-unit: 0
pixel2-batt: 0
pixel2-perf: 0
pixel2-unit: 0
motog5-batt-2: 2
motog5-perf-2: 37
motog5-unit-2: 0
pixel2-batt-2: 2
pixel2-perf-2: 40
pixel2-unit-2: 18
```