### PR TITLE
device_model can be unset

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190812T214125
+      DOCKER_IMAGE_VERSION: 20190813T130830
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190812T214125
+      DOCKER_IMAGE_VERSION: 20190813T130830
   # mozilla-gw-test-3:
   #   device_group_name: test-3
   #   framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190809T110552
+      DOCKER_IMAGE_VERSION: 20190812T195705
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190809T110552
+      DOCKER_IMAGE_VERSION: 20190812T195705
   # mozilla-gw-test-3:
   #   device_group_name: test-3
   #   framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190813T130830
+      DOCKER_IMAGE_VERSION: 20190813T144959
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190813T130830
+      DOCKER_IMAGE_VERSION: 20190813T144959
   # mozilla-gw-test-3:
   #   device_group_name: test-3
   #   framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190812T195705
+      DOCKER_IMAGE_VERSION: 20190812T214125
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190812T195705
+      DOCKER_IMAGE_VERSION: 20190812T214125
   # mozilla-gw-test-3:
   #   device_group_name: test-3
   #   framework_name: mozilla-usb

--- a/mozilla_bitbar_devicepool/__init__.py
+++ b/mozilla_bitbar_devicepool/__init__.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import logging
 
 # TODO: put %(asctime)s back in?
-logging.basicConfig(format='%(threadName)24s %(levelname)-8s %(message)s')
+logging.basicConfig(format='%(threadName)26s %(levelname)-8s %(message)s')
 
 import copy
 import os

--- a/mozilla_bitbar_devicepool/__init__.py
+++ b/mozilla_bitbar_devicepool/__init__.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import logging
 
 # TODO: put %(asctime)s back in?
-logging.basicConfig(format='%(threadName)27s %(levelname)-8s %(message)s')
+logging.basicConfig(format='%(threadName)24s %(levelname)-8s %(message)s')
 
 import copy
 import os

--- a/mozilla_bitbar_devicepool/__init__.py
+++ b/mozilla_bitbar_devicepool/__init__.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import logging
 
 # TODO: put %(asctime)s back in?
-logging.basicConfig(format='%(threadName)22s %(levelname)-8s %(message)s')
+logging.basicConfig(format='%(threadName)27s %(levelname)-8s %(message)s')
 
 import copy
 import os

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -60,7 +60,10 @@ class TestRunManager(object):
         device_group_count = bitbar_device_group['deviceCount']
 
         offline_devices = []
-        temp_offline_devices = get_offline_devices(device_model=project_config['device_model'])
+        if 'device_model' in project_config:
+            temp_offline_devices = get_offline_devices(device_model=project_config['device_model'])
+        else:
+            temp_offline_devices = get_offline_devices()
         for device_name in temp_offline_devices:
             if device_name in device_group:
                 offline_devices.append(device_name)

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -106,7 +106,7 @@ class TestRunManager(object):
 
                 if stats['RUNNING'] or stats['WAITING']:
                     logger.info(
-                        '{:10s} COUNT {} IDLE {} OFFLINE {} DISABLED {} RUNNING {} WAITING {} PENDING {} STARTING {}'.format(
+                        '{:13s} COUNT {} IDLE {} OFFLINE {} DISABLED {} RUNNING {} WAITING {} PENDING {} STARTING {}'.format(
                             device_group_name,
                             stats['COUNT'],
                             stats['IDLE'],

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -60,10 +60,7 @@ class TestRunManager(object):
         device_group_count = bitbar_device_group['deviceCount']
 
         offline_devices = []
-        if 'device_model' in project_config:
-            temp_offline_devices = get_offline_devices(device_model=project_config['device_model'])
-        else:
-            temp_offline_devices = get_offline_devices()
+        temp_offline_devices = get_offline_devices(device_model=project_config.get('device_model', None))
         for device_name in temp_offline_devices:
             if device_name in device_group:
                 offline_devices.append(device_name)


### PR DESCRIPTION
Handles exception below. For the test queues, I left the device type unset... causing this exception.

Also:
  - adjust log line spacing
  - use latest docker image in test pools

```
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]: Traceback (most recent call last):
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 170, in <module>
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:     main()
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 167, in main
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:     args.func(args)
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 58, in test_run_manager
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:     manager.run()
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 210, in run
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:     self.get_bitbar_test_stats(project_name, projects_config[project_name])
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 63, in get_bitbar_test_stats
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]:     temp_offline_devices = get_offline_devices(device_model=project_config['device_model'])
Aug 12 23:49:08 bitbar-devicepool-0 bash[5162]: KeyError: 'device_model'
```