### PR TITLE
remove device_group_name from log line

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -109,8 +109,7 @@ class TestRunManager(object):
 
                 if stats['RUNNING'] or stats['WAITING']:
                     logger.info(
-                        '{:13s} COUNT {} IDLE {} OFFLINE {} DISABLED {} RUNNING {} WAITING {} PENDING {} STARTING {}'.format(
-                            device_group_name,
+                        'COUNT {} IDLE {} OFFLINE {} DISABLED {} RUNNING {} WAITING {} PENDING {} STARTING {}'.format(
                             stats['COUNT'],
                             stats['IDLE'],
                             stats['OFFLINE'],


### PR DESCRIPTION
The thread (project name) is included in the logger format, so the device_group is redundant now.