### PR TITLE
tweak log output

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -131,8 +131,7 @@ class TestRunManager(object):
                         with lock:
                             stats['WAITING'] += 1
 
-                        logger.info('{:10s} test run {} started'.format(
-                            device_group_name,
+                        logger.info('test run {} started'.format(
                             test_run['id']))
                 except Exception as e:
                     logger.error(


### PR DESCRIPTION
device_group_name is redundant here also.