### PR TITLE
fix device group report ordering

### DIFF
--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -38,10 +38,10 @@ class DeviceGroupReport:
             if "-builder" not in group:
                 if 'test' in group:
                     self.test_result_dict[group] = get_len(the_item)
-                elif group.endswith('unit') or group.endswith('perf') or group.endswith('batt'):
-                    self.tcw_result_dict[group] = get_len(the_item)
-                else:
+                elif group.endswith('2'):
                     self.gw_result_dict[group] = get_len(the_item)
+                else:
+                    self.tcw_result_dict[group] = get_len(the_item)
 
 
     def main(self):

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -47,12 +47,12 @@ class DeviceGroupReport:
     def main(self):
         self.get_report_dict()
 
-        print("/// t-c \\\\\\")
+        print("/// tc-w ///")
         for key in sorted(self.tcw_result_dict.keys()):
             print("%s: %s" % (key, self.tcw_result_dict[key]))
-        print("/// g-w \\\\\\")
+        print("/// g-w ///")
         for key in sorted(self.gw_result_dict.keys()):
             print("%s: %s" % (key, self.gw_result_dict[key]))
-        print("/// test \\\\\\")
+        print("/// test ///")
         for key in sorted(self.test_result_dict.keys()):
             print("%s: %s" % (key, self.test_result_dict[key]))

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -16,6 +16,7 @@ class DeviceGroupReport:
     def __init__(self, config_path=None):
         self.gw_result_dict = {}
         self.tcw_result_dict = {}
+        self.test_result_dict = {}
         if not config_path:
             pathname = os.path.dirname(sys.argv[0])
             root_dir = os.path.abspath(os.path.join(pathname, ".."))
@@ -32,10 +33,13 @@ class DeviceGroupReport:
                 print(exc)
 
         for group in conf_yaml["device_groups"]:
+            print("*** %s" % group)
             the_item = conf_yaml["device_groups"][group]
             # filter out the test queue and the builder job
             if "-builder" not in group:
-                if group.endswith('unit') or group.endswith('perf') or group.endswith('batt'):
+                if 'test' in group:
+                    self.test_result_dict[group] = get_len(the_item)
+                elif group.endswith('unit') or group.endswith('perf') or group.endswith('batt'):
                     self.tcw_result_dict[group] = get_len(the_item)
                 else:
                     self.gw_result_dict[group] = get_len(the_item)
@@ -48,3 +52,5 @@ class DeviceGroupReport:
             print("%s: %s" % (key, self.tcw_result_dict[key]))
         for key in sorted(self.gw_result_dict.keys()):
             print("%s: %s" % (key, self.gw_result_dict[key]))
+        for key in sorted(self.test_result_dict.keys()):
+            print("%s: %s" % (key, self.test_result_dict[key]))

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -33,7 +33,6 @@ class DeviceGroupReport:
                 print(exc)
 
         for group in conf_yaml["device_groups"]:
-            print("*** %s" % group)
             the_item = conf_yaml["device_groups"][group]
             # filter out the test queue and the builder job
             if "-builder" not in group:
@@ -48,9 +47,12 @@ class DeviceGroupReport:
     def main(self):
         self.get_report_dict()
 
+        print("/// t-c \\\\\\")
         for key in sorted(self.tcw_result_dict.keys()):
             print("%s: %s" % (key, self.tcw_result_dict[key]))
+        print("/// g-w \\\\\\")
         for key in sorted(self.gw_result_dict.keys()):
             print("%s: %s" % (key, self.gw_result_dict[key]))
+        print("/// test \\\\\\")
         for key in sorted(self.test_result_dict.keys()):
             print("%s: %s" % (key, self.test_result_dict[key]))

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -35,14 +35,16 @@ class DeviceGroupReport:
             the_item = conf_yaml["device_groups"][group]
             # filter out the test queue and the builder job
             if "-builder" not in group:
-                if group.endswith("-2"):
-                    self.gw_result_dict[group] = get_len(the_item)
-                else:
+                if group.endswith('unit') or group.endswith('perf') or group.endswith('batt'):
                     self.tcw_result_dict[group] = get_len(the_item)
+                else:
+                    self.gw_result_dict[group] = get_len(the_item)
+
 
     def main(self):
         self.get_report_dict()
 
-        for a_dict in [self.tcw_result_dict, self.gw_result_dict]:
-            for item in sorted(a_dict):
-                print("%s: %s" % (item, a_dict[item]))
+        for key in sorted(self.tcw_result_dict.keys()):
+            print("%s: %s" % (key, self.tcw_result_dict[key]))
+        for key in sorted(self.gw_result_dict.keys()):
+            print("%s: %s" % (key, self.gw_result_dict[key]))

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -36,13 +36,12 @@ class DeviceGroupReport:
             the_item = conf_yaml["device_groups"][group]
             # filter out the test queue and the builder job
             if "-builder" not in group:
-                if 'test' in group:
+                if "test" in group:
                     self.test_result_dict[group] = get_len(the_item)
-                elif group.endswith('2'):
+                elif group.endswith("2"):
                     self.gw_result_dict[group] = get_len(the_item)
                 else:
                     self.tcw_result_dict[group] = get_len(the_item)
-
 
     def main(self):
         self.get_report_dict()


### PR DESCRIPTION
Organizes the output into sections (g-w, tc-w, and test queues).

```
$ ./bin/device_group_report 
Using config file at '/Users/aerickson/git/mozilla-bitbar-devicepool/config/config.yml'.
/// tc-w ///
motog5-batt: 0
motog5-perf: 0
motog5-unit: 0
pixel2-batt: 0
pixel2-perf: 0
pixel2-unit: 0
/// g-w ///
motog5-batt-2: 2
motog5-perf-2: 37
motog5-unit-2: 0
pixel2-batt-2: 2
pixel2-perf-2: 35
pixel2-unit-2: 21
/// test ///
motog5-test: 1
test-1: 1
test-2: 1
test-3: 0
$
```