### PR TITLE
detect if no workers assigned to a project

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -126,14 +126,18 @@ class TestRunManager(object):
                     if TESTING:
                         logger.info('TESTING MODE: Would be starting test run.')
                     else:
-                        # TODO: check that there are devices assigned to project first
-                        test_run = run_test_for_project(project_name)
-                        # increment so we don't start too many jobs before main thread updates stats
-                        with lock:
-                            stats['WAITING'] += 1
+                        # if there are no devices assigned, the API will throw an exception
+                        # when we try to start, so detect and warn here.
+                        if stats['COUNT'] == 0:
+                            logger.warning("Didn't try to start a job because there are no devices assigned.")
+                        else:
+                            test_run = run_test_for_project(project_name)
+                            # increment so we don't start too many jobs before main thread updates stats
+                            with lock:
+                                stats['WAITING'] += 1
 
-                        logger.info('test run {} started'.format(
-                            test_run['id']))
+                            logger.info('test run {} started'.format(
+                                test_run['id']))
                 except Exception as e:
                     logger.error(
                         'Failed to create test run for group %s (%s: %s).'

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -126,6 +126,7 @@ class TestRunManager(object):
                     if TESTING:
                         logger.info('TESTING MODE: Would be starting test run.')
                     else:
+                        # TODO: check that there are devices assigned to project first
                         test_run = run_test_for_project(project_name)
                         # increment so we don't start too many jobs before main thread updates stats
                         with lock:


### PR DESCRIPTION
The API will throw an exception if we try to start a test for a project without any devices assigned. Detect that state, warn, and don't try to start a test via API.

devicepool0 is currently displaying stacks about unit-g5 queue/project (we catch the exception, so things keep working).

Exception:

```
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]:     mozilla-gw-unittest-g5 ERROR    Failed to create test run for group motog5-unit-2 (RequestResponseError: Request Error: code 400: {"message":"Failed to submit test run! No devices selected to run.","statusCode":400}).
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]: Traceback (most recent call last):
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 129, in handle_queue
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]:     test_run = run_test_for_project(project_name)
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 75, in run_test_for_project
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]:     return run_test_with_configuration(test_configuration)
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 25, in run_test_with_configuration
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]:     headers={'Content-type': 'application/json', 'Accept': 'application/json'})
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 270, in post
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]:     raise RequestResponseError(res.text, res.status_code)
Aug 21 22:41:35 bitbar-devicepool-0 bash[11998]: RequestResponseError: Request Error: code 400: {"message":"Failed to submit test run! No devices selected to run.","statusCode":400}
```

Tested on devicepool0 and seems to be working well:

```
Aug 22 00:45:18 bitbar-devicepool-0 bash[28535]:     mozilla-gw-unittest-g5 INFO     thread starting
Aug 22 00:45:18 bitbar-devicepool-0 bash[28535]:     mozilla-gw-perftest-p2 INFO     test run 1001259 started
Aug 22 00:45:18 bitbar-devicepool-0 bash[28535]:     mozilla-gw-unittest-g5 WARNING  Didn't try to start a job because there are no devices assigned.
Aug 22 00:45:19 bitbar-devicepool-0 bash[28535]:          mozilla-gw-test-1 INFO     thread starting
Aug 22 00:45:20 bitbar-devicepool-0 bash[28535]:     mozilla-gw-perftest-p2 INFO     test run 1001260 started
Aug 22 00:45:22 bitbar-devicepool-0 bash[28535]:     mozilla-gw-perftest-p2 INFO     test run 1001271 started
Aug 22 00:45:25 bitbar-devicepool-0 bash[28535]:     mozilla-gw-perftest-p2 INFO     test run 1001264 started
Aug 22 00:45:25 bitbar-devicepool-0 bash[28535]:                active_jobs INFO     getting active runs
```