### PR TITLE
use latest docker image

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -99,7 +99,7 @@ projects:
   #     TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
   #     TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
   #     # replace with version to test
-  #     # DOCKER_IMAGE_VERSION: 20190809T110552
+  #     # DOCKER_IMAGE_VERSION: 20190813T144959
   mozilla-docker-image-test:
     device_group_name: motog5-test
     device_model: motog5

--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20190731T113428
+      DOCKER_IMAGE_VERSION: 20190813T144959
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:
@@ -109,7 +109,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190731T113428
+      DOCKER_IMAGE_VERSION: 20190813T144959
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
`20190813T144959` built in https://github.com/bclary/mozilla-bitbar-docker/pull/10.