### PR TITLE
use latest test image in test-3 project

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -91,15 +91,15 @@ projects:
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
       DOCKER_IMAGE_VERSION: 20190813T144959
-  # mozilla-gw-test-3:
-  #   device_group_name: test-3
-  #   framework_name: mozilla-usb
-  #   description: used for testing new images
-  #   additional_parameters:
-  #     TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
-  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
-  #     # replace with version to test
-  #     # DOCKER_IMAGE_VERSION: 20190813T144959
+  mozilla-gw-test-3:
+    device_group_name: test-3
+    framework_name: mozilla-usb
+    description: used for testing new images
+    additional_parameters:
+      TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
+      TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
+      # replace with version to test
+      DOCKER_IMAGE_VERSION: 20190822T141403
   mozilla-docker-image-test:
     device_group_name: motog5-test
     device_model: motog5
@@ -151,7 +151,6 @@ device_groups:
     motog5-36:
     motog5-37:
     motog5-38:
-    motog5-39:
   motog5-unit:
   motog5-unit-2:
   motog5-test:
@@ -161,6 +160,7 @@ device_groups:
   test-2:
     pixel2-59:
   test-3:
+    motog5-39:
   motog5-batt:
   motog5-batt-2:
     motog5-08:

--- a/config/config.yml
+++ b/config/config.yml
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190822T141403
+      DOCKER_IMAGE_VERSION: 20190823T115311
   mozilla-docker-image-test:
     device_group_name: motog5-test
     device_model: motog5


### PR DESCRIPTION
`20190822T141403` was built from https://github.com/bclary/mozilla-bitbar-docker/commit/7ef99e005301446e9dbb39c43bc7f41b6ff6b004.
`20190823T115311` was built from https://github.com/bclary/mozilla-bitbar-docker/commit/f04da9f09c6dc167e90a54360630703276e53d8a

