### PR TITLE
use latest image build in test-1 and test-2

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190813T144959
+      DOCKER_IMAGE_VERSION: 20190830T150902
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190813T144959
+      DOCKER_IMAGE_VERSION: 20190830T150902
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb


### PR DESCRIPTION
`20190830T150902`: built from https://github.com/bclary/mozilla-bitbar-docker/commit/3ea00da2de9ceb38ee7feef3847ba22eca6e3e38

Contains the following changes: https://github.com/bclary/mozilla-bitbar-docker/compare/f04da9f09c6dc167e90a54360630703276e53d8a...3ea00da2de9ceb38ee7feef3847ba22eca6e3e38