### PR TITLE
set 20190830T150902 to the default image

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20190813T144959
+      DOCKER_IMAGE_VERSION: 20190830T150902
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
Initially tested on test-3. https://treeherder.mozilla.org/#/jobs?repo=try&revision=800bf27856adce7bb6503f96e5cfa7bfb1524eae

Has been tested on test-1 and test-2 queues recently with sparky's hubless battery tests.