### PR TITLE
Revert "set 20190830T150902 to the default image (#46)"

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20190830T150902
+      DOCKER_IMAGE_VERSION: 20190813T144959
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
This reverts commit 53ffac5518352de8dc402cfbf5ae73bb4a92f7f9.

g-w is exploding on some cluster managers.

```
I 2019-09-09T18:33:50.743777Z bitbar-ubuntu-204: 2019/09/09 18:33:50 goroutine 1 [running]: 
I 2019-09-09T18:33:50.743852Z bitbar-ubuntu-204: runtime/debug.Stack(0xc4204a19c8, 0x855e3c, 0x9a33c3) 
I 2019-09-09T18:33:50.743946Z bitbar-ubuntu-204: 	/home/travis/.gimme/versions/go1.10.8.linux.amd64/src/runtime/debug/stack.go:24 +0xa7 
I 2019-09-09T18:33:50.744018Z bitbar-ubuntu-204: main.HandleCrash(0x8eb7c0, 0xc4204ea000) 
I 2019-09-09T18:33:50.744123Z bitbar-ubuntu-204: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:393 +0x26 
I 2019-09-09T18:33:50.744189Z bitbar-ubuntu-204: main.RunWorker.func1(0xc4204a1dd0) 
I 2019-09-09T18:33:50.744280Z bitbar-ubuntu-204: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:412 +0x52 
I 2019-09-09T18:33:50.744343Z bitbar-ubuntu-204: panic(0x8eb7c0, 0xc4204ea000) 
I 2019-09-09T18:33:50.744445Z bitbar-ubuntu-204: 	/home/travis/.gimme/versions/go1.10.8.linux.amd64/src/runtime/panic.go:502 +0x229 
I 2019-09-09T18:33:50.744494Z bitbar-ubuntu-204: main.RunWorker(0x0) 
I 2019-09-09T18:33:50.744573Z bitbar-ubuntu-204: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:491 +0x1192 
I 2019-09-09T18:33:50.744620Z bitbar-ubuntu-204: main.main() 
I 2019-09-09T18:33:50.744699Z bitbar-ubuntu-204: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:186 +0x926 
I 2019-09-09T18:33:50.744770Z bitbar-ubuntu-204: 2019/09/09 18:33:50  *********** PANIC occurred! *********** 
I 2019-09-09T18:33:50.744883Z bitbar-ubuntu-204: 2019/09/09 18:33:50 Not able to free up enough disk space - require 7340032000 bytes, but only have 7136935936 bytes - and nothing left to delete 
I 2019-09-09T18:33:50.744962Z bitbar-ubuntu-204: 2019/09/09 18:33:50 No sentry project defined, not reporting to sentry 

```