### PR TITLE
set default image to 20190910T102707

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20190813T144959
+      DOCKER_IMAGE_VERSION: 20190910T102707
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
changes included in image: https://github.com/bclary/mozilla-bitbar-docker/compare/3ea00da2de9ceb38ee7feef3847ba22eca6e3e38...4472fd80907d3cb6a2298299f3287b1bcda1a6c9

tested using test-3 queue. https://treeherder.mozilla.org/#/jobs?repo=try&revision=4b5200c1a71b2a057dbad95ecc0341bdad144791

test-1 and test-2 have also been using this image. Sparky has been running hubless battery testing tests.

raptor tests use about 1GB of disk during the run.