### PR TITLE
Revert "set default image to 20190910T102707 (#49)"

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20190910T102707
+      DOCKER_IMAGE_VERSION: 20190813T144959
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
This reverts commit edd7516c133ffcb253edba34460f045a416fba86.

This was done manually yesterday. Make it official.

The image doesn't seem to be the problem, but we're not going to use it (creating a new one with more recent g-w).