### PR TITLE
use 20190913T115614 everywhere

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20190813T144959
+      DOCKER_IMAGE_VERSION: 20190913T115614
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190910T102707
+      DOCKER_IMAGE_VERSION: 20190913T115614
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190910T102707
+      DOCKER_IMAGE_VERSION: 20190913T115614
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190910T102707
+      DOCKER_IMAGE_VERSION: 20190913T115614
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190910T102707
+      DOCKER_IMAGE_VERSION: 20190913T115614
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
`09-13 12:27:21.820 Successfully tagged mozilla-image:20190913T115614`

contains the following changes: https://github.com/bclary/mozilla-bitbar-docker/compare/4472fd80907d3cb6a2298299f3287b1bcda1a6c9...master

No `mach try` testing has been done as the previous image has been qualified and we're in a meltdown state. I've verified g-w starts up (the config is good).