### PR TITLE
avoid exploding when a device is offline

### DIFF
--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -121,7 +121,7 @@ def configure_device_groups(update_bitbar=False):
         add_device_names = new_device_group_names - bitbar_device_group_names
 
         delete_device_ids = [ devices_cache[name]['id'] for name in delete_device_names ]
-        add_device_ids = [ devices_cache[name]['id'] for name in add_device_names ]
+        add_device_ids = [ devices_cache[name]['id'] for name in add_device_names if name in devices_cache ]
 
         for device_id in delete_device_ids:
             if update_bitbar:


### PR DESCRIPTION
Exception seen:

```
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]: Traceback (most recent call last):
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 170, in <module>
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:     main()
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 167, in main
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:     args.func(args)
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 55, in test_run_manager
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:     configuration.configure(bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar)
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/configuration.py", line 73, in configure
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:     configure_device_groups(update_bitbar=update_bitbar)
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/configuration.py", line 124, in configure_device_groups
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]:     add_device_ids = [ devices_cache[name]['id'] for name in add_device_names ]
Sep 13 19:57:13 bitbar-devicepool-0 bash[17489]: KeyError: 'motog5-01'
```