### PR TITLE
use 9/17 image in test queues

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190913T141232
+      DOCKER_IMAGE_VERSION: 20190917T123157
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190913T141232
+      DOCKER_IMAGE_VERSION: 20190917T123157
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190913T141232
+      DOCKER_IMAGE_VERSION: 20190917T123157
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190913T141232
+      DOCKER_IMAGE_VERSION: 20190917T123157
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
changes included: https://github.com/bclary/mozilla-bitbar-docker/commit/559de890ccbea68dec028dae86fa32cebcbd4c0a

`09-17 12:36:09.740 Successfully tagged mozilla-image:20190917T123157`


