### PR TITLE
use 20190920T121854 in test queues

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190918T171937
+      DOCKER_IMAGE_VERSION: 20190920T121854
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190918T171937
+      DOCKER_IMAGE_VERSION: 20190920T121854
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190918T171937
+      DOCKER_IMAGE_VERSION: 20190920T121854
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190918T171937
+      DOCKER_IMAGE_VERSION: 20190920T121854
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
20190920T121854 is based on https://github.com/bclary/mozilla-bitbar-docker/pull/25/commits/7056875b5f26a09ebbed016ab832f00d72bb05a6 (part of https://github.com/bclary/mozilla-bitbar-docker/pull/25)
- Previous build of this PR lacked envsubst (not part of the base install in 18.04).

build: https://mozilla.testdroid.com/#testing/test-run/1006154/1136035
`09-20 13:07:03.718 Successfully tagged mozilla-image:20190920T121854`
