### PR TITLE
don't log10() negative numbers

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -101,6 +101,8 @@ class TestRunManager(object):
                     logger.warning("exception raised when calling get_taskcluster_pending_tasks.")
                     logger.warning(e)
                     pending_tasks = 0
+                # warning: only take the log of positive non-zero numbers, or a
+                # "ValueError: math domain error" will be raised
                 jobs_to_start = min(pending_tasks,
                                     stats['IDLE'] - stats['WAITING'] + 1 + int(math.log10(1 + pending_tasks)))
                 if jobs_to_start < 0:

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -100,8 +100,7 @@ class TestRunManager(object):
                 except requests.ConnectionError as e:
                     logger.warning("exception raised when calling get_taskcluster_pending_tasks.")
                     logger.warning(e)
-                    # ensure jobs_to_start is set to 0 below
-                    pending_tasks = -1
+                    pending_tasks = 0
                 jobs_to_start = min(pending_tasks,
                                     stats['IDLE'] - stats['WAITING'] + 1 + int(math.log10(1 + pending_tasks)))
                 if jobs_to_start < 0:


### PR DESCRIPTION
Fixes exception seen today.

```
Oct 01 00:31:27 bitbar-devicepool-0 bash[13384]: Exception in thread mozilla-gw-perftest-g5:
Oct 01 00:31:27 bitbar-devicepool-0 bash[13384]: Traceback (most recent call last):
Oct 01 00:31:27 bitbar-devicepool-0 bash[13384]: File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
Oct 01 00:31:27 bitbar-devicepool-0 bash[13384]: self.run()
Oct 01 00:31:27 bitbar-devicepool-0 bash[13384]: File "/usr/lib/python2.7/threading.py", line 754, in run
Oct 01 00:31:27 bitbar-devicepool-0 bash[13384]: self.__target(*self.__args, **self.__kwargs)
Oct 01 00:31:27 bitbar-devicepool-0 bash[13384]: File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 106, in handle_queue
Oct 01 00:31:27 bitbar-devicepool-0 bash[13384]: stats['IDLE'] - stats['WAITING'] + 1 + int(math.log10(1 + pending_tasks)))
Oct 01 00:31:27 bitbar-devicepool-0 bash[13384]: ValueError: math domain error
```