### PR TITLE
set 18.04 image as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20191022T154928
+      DOCKER_IMAGE_VERSION: 20191023T180043
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
Images built:
- first: `09-20 13:07:03.718 Successfully tagged mozilla-image:20190920T121854` (see https://github.com/bclary/mozilla-bitbar-devicepool/pull/57)
- second (rebased on master to get g-w counter file deletion): `10-23 15:07:01.613 Successfully tagged mozilla-image:20191023T180043` (see https://github.com/bclary/mozilla-bitbar-devicepool/pull/65)

---

## final testing

- https://treeherder.mozilla.org/#/jobs?repo=try&revision=165a8f9f028abb58ea2e52d6f193f8a07e1f214e

## preliminary perf testing

Use https://treeherder.mozilla.org/perf.html#/compare to compare performance to default.

```
./mach try fuzzy --no-artifact  --full --query "'android-hw-g5 \!power \!nightly \!pgo '-1-" --rebuild 10
```

### round 1
https://treeherder.mozilla.org/#/jobs?repo=try&group_state=expanded&revision=2513360a9b7f7fe4a829317c37b1f0474a957e39
  - https://treeherder.mozilla.org/perf.html#/compare?originalProject=mozilla-central&newProject=try&newRevision=c1b2837680c5615e4a7c5c88fa565074f00c2f82&framework=10&selectedTimeRange=1209600

### round 2
10 retries
https://treeherder.mozilla.org/#/jobs?repo=try&revision=9fb71a4043c2068e020eedfdea5f37c2da93b8f6  
  - https://treeherder.mozilla.org/perf.html#/compare?originalProject=mozilla-central&newProject=try&newRevision=9fb71a4043c2068e020eedfdea5f37c2da93b8f6&framework=10&selectedTimeRange=1209600
    - click "Hide uncomparable results"

### round 3
10 retries, with try push for base (so retries work from perfherder UI)
```
- @  496692:a99e10ff9a43 aerickson all android-hw jobs to gecko-t-bitbar-gw-test-3
o    496691:480000073f46 catlee central Bug 1542819: Use worker aliases for signing to unbreak TB. r=tomprince a=Aryx
```
- reference run: https://treeherder.mozilla.org/#/jobs?repo=try&revision=685aa00ed8c6e47a624c0832326528df1c4b568d
- 1804 run: https://treeherder.mozilla.org/#/jobs?repo=try&revision=da3f16d98c37ac6090a60cbbf770f39ae78ab9dc
- comparison: https://treeherder.mozilla.org/perf.html#/compare?originalProject=try&originalRevision=685aa00ed8c6e47a624c0832326528df1c4b568d&newProject=try&newRevision=da3f16d98c37ac6090a60cbbf770f39ae78ab9dc&framework=10
  - results summary: Most tests decreased in time, the largest increase is ~3%.
  - results approved by perf-sheriffs 10/21.
