### PR TITLE
exit when test files are archived

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -6,6 +6,7 @@ import math
 import signal
 import threading
 import time
+import sys
 
 import requests
 
@@ -15,6 +16,8 @@ from mozilla_bitbar_devicepool.devices import get_offline_devices
 from mozilla_bitbar_devicepool.runs import (get_active_test_runs,
                                             run_test_for_project)
 from mozilla_bitbar_devicepool.taskcluster import get_taskcluster_pending_tasks
+
+from testdroid import RequestResponseError
 
 #
 # WARNING: not used everywhere yet!!!
@@ -139,6 +142,12 @@ class TestRunManager(object):
 
                             logger.info('test run {} started'.format(
                                 test_run['id']))
+                except RequestResponseError as e:
+                    # TODO: inspect message for
+                    #   "FileEntity with id 1508313 does not exist"
+                    logger.error("Test files have been archived. Exiting so configuration is rerun...")
+                    logger.error("%s: %s" % (e.__class__.__name__, e.message))
+                    sys.exit(1)
                 except Exception as e:
                     logger.error(
                         'Failed to create test run for group %s (%s: %s).'

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -7,7 +7,6 @@ import re
 import signal
 import threading
 import time
-import sys
 
 import requests
 
@@ -146,10 +145,10 @@ class TestRunManager(object):
                             logger.info('test run {} started'.format(
                                 test_run['id']))
                 except RequestResponseError as e:
-                    if e.statusCode == 404 and re.search(ARCHIVED_FILE_REGEX, e.message):
+                    if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, e.message):
                         logger.error("Test files have been archived. Exiting so configuration is rerun...")
                         logger.error("%s: %s" % (e.__class__.__name__, e.message))
-                        sys.exit(1)
+                        self.state = 'STOP'
                     else:
                         logger.error("%s: %s" % (e.__class__.__name__, e.message))
                 except Exception as e:


### PR DESCRIPTION
Exit when the exception is seen. Systemd will restart the service and configuration will run.

## testing

diff:
```diff
diff --git a/mozilla_bitbar_devicepool/test_run_manager.py b/mozilla_bitbar_devicepool/test_run_manager.py
index 715a596..951aabe 100644
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -23,7 +23,7 @@ from testdroid import RequestResponseError
 # WARNING: not used everywhere yet!!!
 #
 # don't fire calls at bitbar, just mention you would
-TESTING = False
+TESTING = True
 
 CACHE = None
 CONFIG = None
@@ -131,6 +131,8 @@ class TestRunManager(object):
                 try:
                     if TESTING:
                         logger.info('TESTING MODE: Would be starting test run.')
+                        a = RequestResponseError("FileEntity with id 444444 does not exist", 404)
+                        raise(a)
                     else:
                         # if there are no devices assigned, the API will throw an exception
                         # when we try to start, so detect and warn here.
```

output:
```bash
(venv) ➜  mozilla-bitbar-devicepool git:(fix_archived_file_error) ✗  python mozilla_bitbar_devicepool/main.py start-test-run-manager --update-bitbar
                MainThread INFO     configure: starting configuration
                MainThread INFO     configure_device_groups: configuring group pixel2-batt-2
                MainThread INFO     configure_device_groups: configuring group motog5-batt
                MainThread INFO     configure_device_groups: configuring group pixel2-perf
                MainThread INFO     configure_device_groups: configuring group motog5-perf-2
                MainThread INFO     configure_device_groups: configuring group motog5-perf
                MainThread INFO     configure_device_groups: configuring group pixel2-unit-2
                MainThread INFO     configure_device_groups: configuring group motog5-unit
                MainThread INFO     configure_device_groups: configuring group pixel2-batt
                MainThread INFO     configure_device_groups: configuring group pixel2-unit
                MainThread INFO     configure_device_groups: configuring group motog5-unit-2
                MainThread INFO     configure_device_groups: configuring group motog4-docker-builder
                MainThread INFO     configure_device_groups: configuring group motog5-test
                MainThread INFO     configure_device_groups: configuring group test-2
                MainThread INFO     configure_device_groups: configuring group test-1
                MainThread INFO     configure_device_groups: configuring group pixel2-perf-2
                MainThread INFO     configure_device_groups: configuring group test-3
                MainThread INFO     configure_device_groups: configuring group motog5-batt-2
                MainThread INFO     configure_projects: mozilla-gw-perftest-p2 (1/11): configuring...
                MainThread INFO     configure_projects: mozilla-gw-perftest-p2 (1/11): configuring test file
                MainThread INFO     configure_projects: mozilla-gw-perftest-p2 (1/11): configuring application file
                MainThread INFO     configure_projects: mozilla-gw-perftest-g5 (2/11): configuring...
                MainThread INFO     configure_projects: mozilla-gw-perftest-g5 (2/11): configuring test file
                MainThread INFO     configure_projects: mozilla-gw-perftest-g5 (2/11): configuring application file
                MainThread INFO     configure_projects: mozilla-docker-image-test (3/11): configuring...
                MainThread INFO     configure_projects: mozilla-docker-image-test (3/11): configuring test file
                MainThread INFO     configure_projects: mozilla-docker-image-test (3/11): configuring application file
                MainThread INFO     configure_projects: mozilla-gw-batttest-g5 (4/11): configuring...
                MainThread INFO     configure_projects: mozilla-gw-batttest-g5 (4/11): configuring test file
                MainThread INFO     configure_projects: mozilla-gw-batttest-g5 (4/11): configuring application file
                MainThread INFO     configure_projects: mozilla-gw-unittest-g5 (5/11): configuring...
                MainThread INFO     configure_projects: mozilla-gw-unittest-g5 (5/11): configuring test file
                MainThread INFO     configure_projects: mozilla-gw-unittest-g5 (5/11): configuring application file
                MainThread INFO     configure_projects: mozilla-gw-batttest-p2 (6/11): configuring...
                MainThread INFO     configure_projects: mozilla-gw-batttest-p2 (6/11): configuring test file
                MainThread INFO     configure_projects: mozilla-gw-batttest-p2 (6/11): configuring application file
                MainThread INFO     configure_projects: mozilla-gw-unittest-p2 (7/11): configuring...
                MainThread INFO     configure_projects: mozilla-gw-unittest-p2 (7/11): configuring test file
                MainThread INFO     configure_projects: mozilla-gw-unittest-p2 (7/11): configuring application file
                MainThread INFO     configure_projects: defaults (8/11): skipping
                MainThread INFO     configure_projects: mozilla-gw-test-2 (9/11): configuring...
                MainThread INFO     configure_projects: mozilla-gw-test-2 (9/11): configuring test file
                MainThread INFO     configure_projects: mozilla-gw-test-2 (9/11): configuring application file
                MainThread INFO     configure_projects: mozilla-gw-test-3 (10/11): configuring...
                MainThread INFO     configure_projects: mozilla-gw-test-3 (10/11): configuring test file
                MainThread INFO     configure_projects: mozilla-gw-test-3 (10/11): configuring application file
                MainThread INFO     configure_projects: mozilla-gw-test-1 (11/11): configuring...
                MainThread INFO     configure_projects: mozilla-gw-test-1 (11/11): configuring test file
                MainThread INFO     configure_projects: mozilla-gw-test-1 (11/11): configuring application file
                MainThread INFO     configure: configuration took 20.0319368839 seconds
                MainThread INFO     test-run-manager: loading existing runs
               active_jobs INFO     getting active runs
    mozilla-gw-perftest-p2 INFO     thread starting
    mozilla-gw-perftest-p2 INFO     COUNT 35 IDLE 4 OFFLINE 0 DISABLED 0 RUNNING 31 WAITING 7 PENDING 539 STARTING 0
    mozilla-gw-perftest-g5 INFO     thread starting
    mozilla-gw-perftest-g5 INFO     COUNT 36 IDLE 8 OFFLINE 0 DISABLED 0 RUNNING 28 WAITING 10 PENDING 136 STARTING 1
    mozilla-gw-perftest-g5 INFO     TESTING MODE: Would be starting test run.
    mozilla-gw-perftest-g5 ERROR    Test files have been archived. Exiting so configuration is rerun...
    mozilla-gw-perftest-g5 ERROR    RequestResponseError: Request Error: code 404: FileEntity with id 444444 does not exist
    mozilla-gw-perftest-g5 INFO     thread exiting
 mozilla-docker-image-test INFO     thread starting
 mozilla-docker-image-test INFO     thread exiting
    mozilla-gw-batttest-g5 INFO     thread starting
    mozilla-gw-batttest-g5 INFO     thread exiting
    mozilla-gw-unittest-g5 INFO     thread starting
    mozilla-gw-unittest-g5 INFO     thread exiting
    mozilla-gw-batttest-p2 INFO     thread starting
    mozilla-gw-batttest-p2 INFO     thread exiting
    mozilla-gw-unittest-p2 INFO     thread starting
    mozilla-gw-unittest-p2 INFO     thread exiting
         mozilla-gw-test-2 INFO     thread starting
         mozilla-gw-test-2 INFO     thread exiting
         mozilla-gw-test-3 INFO     thread starting
         mozilla-gw-test-3 INFO     thread exiting
         mozilla-gw-test-1 INFO     thread starting
                MainThread INFO     main thread exiting
         mozilla-gw-test-1 INFO     thread exiting
    mozilla-gw-perftest-p2 INFO     thread exiting
(venv) ➜  mozilla-bitbar-devicepool git:(fix_archived_file_error) ✗ 
```


## original exception

```
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]: RequestResponseError: Request Error: code 404: {"message":"FileEntity with id 1508313 does not exist","statusCode":404}
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]:     mozilla-gw-perftest-g5 ERROR    Failed to create test run for group motog5-perf-2 (RequestResponseError: Request Error: code 404: {"message":"FileEntity with id 1508313 does not exist","statusCode":404}).
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]: Traceback (most recent call last):
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 135, in handle_queue
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]:     test_run = run_test_for_project(project_name)
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 75, in run_test_for_project
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]:     return run_test_with_configuration(test_configuration)
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 25, in run_test_with_configuration
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]:     headers={'Content-type': 'application/json', 'Accept': 'application/json'})
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 270, in post
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]:     raise RequestResponseError(res.text, res.status_code)
Oct 07 13:23:12 bitbar-devicepool-0 bash[937]: RequestResponseError: Request Error: code 404: {"message":"FileEntity with id 1508313 does not exist","statusCode":404}
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]:     mozilla-gw-perftest-g5 ERROR    Failed to create test run for group motog5-perf-2 (RequestResponseError: Request Error: code 404: {"message":"FileEntity with id 1508313 does not exist","statusCode":404}).
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]: Traceback (most recent call last):
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 135, in handle_queue
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]:     test_run = run_test_for_project(project_name)
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 75, in run_test_for_project
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]:     return run_test_with_configuration(test_configuration)
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 25, in run_test_with_configuration
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]:     headers={'Content-type': 'application/json', 'Accept': 'application/json'})
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 270, in post
Oct 07 13:23:13 bitbar-devicepool-0 bash[937]:     raise RequestResponseError(res.text, res.status_code)
```