### PR TITLE
handle missing files when configuring

### DIFF
--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -48,11 +48,11 @@ FILESPATH = None
 CONFIG = None
 
 
-class ConfigurationExceptionBase(Exception):
+class ConfigurationException(Exception):
     def __init__(self, message):
         self.message = message
 
-class ConfigurationFileException(ConfigurationExceptionBase):
+class ConfigurationFileException(ConfigurationException):
     pass
 
 

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import os
 import threading
 import time
+import sys
 
 import yaml
 
@@ -70,8 +71,13 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
 
     logger.info('configure: starting configuration')
     start = time.time()
-    configure_device_groups(update_bitbar=update_bitbar)
-    configure_projects(update_bitbar=update_bitbar)
+    try:
+        configure_device_groups(update_bitbar=update_bitbar)
+        configure_projects(update_bitbar=update_bitbar)
+    except IOError as e:
+        logger.error("Test files seem to be missing! Please place and restart. Exiting...")
+        logger.error("%s: %s" % (e.__class__.__name__, e.message))
+        sys.exit(1)
     end = time.time()
     diff = end - start
     logger.info('configure: configuration took {} seconds'.format(diff))

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -77,6 +77,7 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
 
     with open(bitbar_configpath) as bitbar_configfile:
         CONFIG = yaml.load(bitbar_configfile.read(), Loader=yaml.SafeLoader)
+
     logger.info('configure: performing checks')
     try:
         configuration_preflight()
@@ -84,6 +85,7 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
         logger.error(e.message)
         logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
         sys.exit(1)
+
     logger.info('configure: starting configuration')
     start = time.time()
     configure_device_groups(update_bitbar=update_bitbar)

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -108,7 +108,7 @@ def expand_configuration():
 
         project_config = projects_config[project_name]
         # Set the default project values.
-        project_config = projects_config[project_name] = apply_dict_defaults(project_config, project_defaults)
+        projects_config[project_name] = apply_dict_defaults(project_config, project_defaults)
 
 def configure_device_groups(update_bitbar=False):
     """Configure device groups from configuration.

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -78,13 +78,14 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
     with open(bitbar_configpath) as bitbar_configfile:
         CONFIG = yaml.load(bitbar_configfile.read(), Loader=yaml.SafeLoader)
 
-    logger.info('configure: performing checks')
-    try:
-        configuration_preflight()
-    except ConfigurationFileException as e:
-        logger.error(e.message)
-        logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
-        sys.exit(1)
+    if update_bitbar:
+        logger.info('configure: performing checks')
+        try:
+            configuration_preflight()
+        except ConfigurationFileException as e:
+            logger.error(e.message)
+            logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
+            sys.exit(1)
 
     logger.info('configure: starting configuration')
     start = time.time()

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -48,10 +48,11 @@ FILESPATH = None
 CONFIG = None
 
 
-class TestFileUploadFailedException(Exception):
-    pass
+class ConfigurationExceptionBase(Exception):
+    def __init__(self, message):
+        self.message = message
 
-class ApplicationFileUploadFailedException(Exception):
+class ConfigurationFileUploadException(ConfigurationExceptionBase):
     pass
 
 
@@ -82,8 +83,8 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
     try:
         configure_device_groups(update_bitbar=update_bitbar)
         configure_projects(update_bitbar=update_bitbar)
-    except IOError as e:
-        logger.error("Test files seem to be missing! Please place and restart. Exiting...")
+    except ConfigurationFileUploadException as e:
+        logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
         logger.error("%s: %s" % (e.__class__.__name__, e.message))
         sys.exit(1)
     end = time.time()
@@ -209,7 +210,7 @@ def configure_projects(update_bitbar=False):
                         file_path = os.path.join(FILESPATH, file_name)
                         TESTDROID.upload_test_file(bitbar_project['id'], file_path)
                     except IOError:
-                        raise TestFileUploadFailedException("'%s' does not exist!" % file_path)
+                        raise ConfigurationFileUploadException("'%s' does not exist!" % file_path)
                     bitbar_file = get_files(name=file_name, inputtype='test')[-1]
                 else:
                     raise Exception('Test file {} not found and not configured to update bitbar configuration!'.format(file_name))
@@ -227,7 +228,7 @@ def configure_projects(update_bitbar=False):
                         TESTDROID.upload_application_file(bitbar_project['id'],
                                                           os.path.join(FILESPATH, file_name))
                     except IOError:
-                        raise ApplicationFileUploadFailedException("'%s' does not exist!" % file_name)
+                        raise ConfigurationFileUploadException("'%s' does not exist!" % file_name)
                     bitbar_file = get_files(name=file_name, inputtype='application')[-1]
                 else:
                     raise Exception('Application file {} not found and not configured to update bitbar configuration!'.format(file_name))

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -75,10 +75,12 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
 
     FILESPATH=filespath
 
+    logger.info('configure: starting configuration')
+    start = time.time()
+
     with open(bitbar_configpath) as bitbar_configfile:
         CONFIG = yaml.load(bitbar_configfile.read(), Loader=yaml.SafeLoader)
     expand_configuration()
-
     if update_bitbar:
         logger.info('configure: performing checks')
         try:
@@ -87,11 +89,9 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
             logger.error(e.message)
             logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
             sys.exit(1)
-
-    logger.info('configure: starting configuration')
-    start = time.time()
     configure_device_groups(update_bitbar=update_bitbar)
     configure_projects(update_bitbar=update_bitbar)
+
     end = time.time()
     diff = end - start
     logger.info('configure: configuration took {} seconds'.format(diff))

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -239,8 +239,6 @@ def configure_projects(update_bitbar=False):
                     file_path = os.path.join(FILESPATH, file_name)
                     if not os.path.exists(file_path):
                         raise ConfigurationFileException("'%s' does not exist!" % file_path)
-                    else:
-                        print("File exists %s" % file_path)
                     TESTDROID.upload_test_file(bitbar_project['id'], file_path)
                     bitbar_file = get_files(name=file_name, inputtype='test')[-1]
                 else:
@@ -258,8 +256,6 @@ def configure_projects(update_bitbar=False):
                     file_path = os.path.join(FILESPATH, file_name)
                     if not os.path.exists(file_path):
                         raise ConfigurationFileException("'%s' does not exist!" % file_path)
-                    else:
-                        print("File exists %s" % file_path)
                     TESTDROID.upload_application_file(bitbar_project['id'], file_path)
                     bitbar_file = get_files(name=file_name, inputtype='application')[-1]
                 else:

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -165,12 +165,9 @@ def configuration_preflight():
     counter = 0
     for project_name in projects_config:
         counter += 1
-        log_header = "configuration_preflight: {} ({}/{})".format(project_name, counter, project_total)
 
         if project_name == 'defaults':
-            # logger.info('{}: skipping'.format(log_header))
             continue
-        # logger.info('{}: checking...'.format(log_header))
 
         project_config = projects_config[project_name]
         project_config = projects_config[project_name] = apply_dict_defaults(project_config, project_defaults)
@@ -178,7 +175,6 @@ def configuration_preflight():
         framework_name = project_config['framework_name']
         BITBAR_CACHE['frameworks'][framework_name] = get_frameworks(name=framework_name)[0]
 
-        # logger.info('{}: pre-flighting test file'.format(log_header))
         file_name =  project_config.get('test_file')
         if file_name:
             file_path = os.path.join(FILESPATH, file_name)
@@ -187,7 +183,6 @@ def configuration_preflight():
             else:
                 print("File exists %s" % file_path)
 
-        # logger.info('{}: pre-flighting application file'.format(log_header))
         file_name = project_config.get('application_file')
         if file_name:
             file_path = os.path.join(FILESPATH, file_name)

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -156,8 +156,9 @@ def configure_device_groups(update_bitbar=False):
 
         BITBAR_CACHE['device_groups'][device_group_name] = bitbar_device_group
 
-# ensures all things to do configuration are present
 def configuration_preflight():
+    """Perform checks to ensure configuration works.
+    """
     projects_config = CONFIG['projects']
     project_defaults = projects_config['defaults']
 

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -172,9 +172,6 @@ def configuration_preflight():
         project_config = projects_config[project_name]
         project_config = projects_config[project_name] = apply_dict_defaults(project_config, project_defaults)
 
-        framework_name = project_config['framework_name']
-        BITBAR_CACHE['frameworks'][framework_name] = get_frameworks(name=framework_name)[0]
-
         file_name =  project_config.get('test_file')
         if file_name:
             file_path = os.path.join(FILESPATH, file_name)

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -110,6 +110,9 @@ def expand_configuration():
         # Set the default project values.
         projects_config[project_name] = apply_dict_defaults(project_config, project_defaults)
 
+    # TODO: remove 'defaults' from CONFIG['projects']?
+    #   - would save later code from having to exclude it
+
 def configure_device_groups(update_bitbar=False):
     """Configure device groups from configuration.
 

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -77,11 +77,12 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
 
     with open(bitbar_configpath) as bitbar_configfile:
         CONFIG = yaml.load(bitbar_configfile.read(), Loader=yaml.SafeLoader)
+    logger.info('configure: performing checks')
     try:
         configuration_preflight()
     except ConfigurationFileException as e:
+        logger.error(e.message)
         logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
-        logger.error("%s: %s" % (e.__class__.__name__, e.message))
         sys.exit(1)
     logger.info('configure: starting configuration')
     start = time.time()
@@ -167,9 +168,9 @@ def configuration_preflight():
         log_header = "configuration_preflight: {} ({}/{})".format(project_name, counter, project_total)
 
         if project_name == 'defaults':
-            logger.info('{}: skipping'.format(log_header))
+            # logger.info('{}: skipping'.format(log_header))
             continue
-        logger.info('{}: checking...'.format(log_header))
+        # logger.info('{}: checking...'.format(log_header))
 
         project_config = projects_config[project_name]
         project_config = projects_config[project_name] = apply_dict_defaults(project_config, project_defaults)

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -47,6 +47,14 @@ BITBAR_CACHE = {
 FILESPATH = None
 CONFIG = None
 
+
+class TestFileUploadFailedException(Exception):
+    pass
+
+class ApplicationFileUploadFailedException(Exception):
+    pass
+
+
 def get_filespath():
     """Return files path where application and test files are kept.
     """
@@ -197,8 +205,11 @@ def configure_projects(update_bitbar=False):
                 bitbar_file = bitbar_files[-1]
             else:
                 if update_bitbar:
-                    TESTDROID.upload_test_file(bitbar_project['id'],
-                                               os.path.join(FILESPATH, file_name))
+                    try:
+                        file_path = os.path.join(FILESPATH, file_name)
+                        TESTDROID.upload_test_file(bitbar_project['id'], file_path)
+                    except IOError:
+                        raise TestFileUploadFailedException("'%s' does not exist!" % file_path)
                     bitbar_file = get_files(name=file_name, inputtype='test')[-1]
                 else:
                     raise Exception('Test file {} not found and not configured to update bitbar configuration!'.format(file_name))
@@ -212,8 +223,11 @@ def configure_projects(update_bitbar=False):
                 bitbar_file = bitbar_files[-1]
             else:
                 if update_bitbar:
-                    TESTDROID.upload_application_file(bitbar_project['id'],
-                                                      os.path.join(FILESPATH, file_name))
+                    try:
+                        TESTDROID.upload_application_file(bitbar_project['id'],
+                                                          os.path.join(FILESPATH, file_name))
+                    except IOError:
+                        raise ApplicationFileUploadFailedException("'%s' does not exist!" % file_name)
                     bitbar_file = get_files(name=file_name, inputtype='application')[-1]
                 else:
                     raise Exception('Application file {} not found and not configured to update bitbar configuration!'.format(file_name))

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -52,6 +52,7 @@ class ConfigurationException(Exception):
     def __init__(self, message):
         self.message = message
 
+
 class ConfigurationFileException(ConfigurationException):
     pass
 

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -161,11 +161,7 @@ def configuration_preflight():
     projects_config = CONFIG['projects']
     project_defaults = projects_config['defaults']
 
-    project_total = len(projects_config)
-    counter = 0
     for project_name in projects_config:
-        counter += 1
-
         if project_name == 'defaults':
             continue
 

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -81,14 +81,13 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
     with open(bitbar_configpath) as bitbar_configfile:
         CONFIG = yaml.load(bitbar_configfile.read(), Loader=yaml.SafeLoader)
     expand_configuration()
-    if update_bitbar:
-        logger.info('configure: performing checks')
-        try:
-            configuration_preflight()
-        except ConfigurationFileException as e:
-            logger.error(e.message)
-            logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
-            sys.exit(1)
+    logger.info('configure: performing checks')
+    try:
+        configuration_preflight()
+    except ConfigurationFileException as e:
+        logger.error(e.message)
+        logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
+        sys.exit(1)
     configure_device_groups(update_bitbar=update_bitbar)
     configure_projects(update_bitbar=update_bitbar)
 

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -77,16 +77,16 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
 
     with open(bitbar_configpath) as bitbar_configfile:
         CONFIG = yaml.load(bitbar_configfile.read(), Loader=yaml.SafeLoader)
-
-    logger.info('configure: starting configuration')
-    start = time.time()
     try:
-        configure_device_groups(update_bitbar=update_bitbar)
-        configure_projects(update_bitbar=update_bitbar)
+        configuration_preflight()
     except ConfigurationFileException as e:
         logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
         logger.error("%s: %s" % (e.__class__.__name__, e.message))
         sys.exit(1)
+    logger.info('configure: starting configuration')
+    start = time.time()
+    configure_device_groups(update_bitbar=update_bitbar)
+    configure_projects(update_bitbar=update_bitbar)
     end = time.time()
     diff = end - start
     logger.info('configure: configuration took {} seconds'.format(diff))
@@ -164,23 +164,20 @@ def configuration_preflight():
     counter = 0
     for project_name in projects_config:
         counter += 1
-        log_header = "configure_projects: {} ({}/{})".format(project_name, counter, project_total)
+        log_header = "configuration_preflight: {} ({}/{})".format(project_name, counter, project_total)
 
         if project_name == 'defaults':
             logger.info('{}: skipping'.format(log_header))
             continue
-        logger.info('{}: configuring...'.format(log_header))
+        logger.info('{}: checking...'.format(log_header))
 
         project_config = projects_config[project_name]
-        # Set the default project values.
         project_config = projects_config[project_name] = apply_dict_defaults(project_config, project_defaults)
-
-        # bitbar_projects = get_projects(name=project_name)
 
         framework_name = project_config['framework_name']
         BITBAR_CACHE['frameworks'][framework_name] = get_frameworks(name=framework_name)[0]
 
-        logger.info('{}: pre-flighting test file'.format(log_header))
+        # logger.info('{}: pre-flighting test file'.format(log_header))
         file_name =  project_config.get('test_file')
         if file_name:
             file_path = os.path.join(FILESPATH, file_name)
@@ -189,7 +186,7 @@ def configuration_preflight():
             else:
                 print("File exists %s" % file_path)
 
-        logger.info('{}: pre-flighting application file'.format(log_header))
+        # logger.info('{}: pre-flighting application file'.format(log_header))
         file_name = project_config.get('application_file')
         if file_name:
             file_path = os.path.join(FILESPATH, file_name)

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -196,8 +196,6 @@ def configuration_preflight():
             else:
                 print("File exists %s" % file_path)
 
-
-
 def configure_projects(update_bitbar=False):
     """Configure projects from configuration.
 

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -170,6 +170,7 @@ def configuration_preflight():
             continue
 
         project_config = projects_config[project_name]
+        # Set the default project values.
         project_config = projects_config[project_name] = apply_dict_defaults(project_config, project_defaults)
 
         file_name =  project_config.get('test_file')

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -113,6 +113,29 @@ def expand_configuration():
     # TODO: remove 'defaults' from CONFIG['projects']?
     #   - would save later code from having to exclude it
 
+def configuration_preflight():
+    """Ensure that everything necessary for configuration is present.
+    """
+    projects_config = CONFIG['projects']
+
+    for project_name in projects_config:
+        if project_name == 'defaults':
+            continue
+
+        project_config = projects_config[project_name]
+        file_name =  project_config.get('test_file')
+        if file_name:
+            file_path = os.path.join(FILESPATH, file_name)
+            if not os.path.exists(file_path):
+                raise ConfigurationFileException("'%s' does not exist!" % file_path)
+
+        file_name = project_config.get('application_file')
+        if file_name:
+            file_path = os.path.join(FILESPATH, file_name)
+            if not os.path.exists(file_path):
+                raise ConfigurationFileException("'%s' does not exist!" % file_path)
+
+
 def configure_device_groups(update_bitbar=False):
     """Configure device groups from configuration.
 
@@ -175,28 +198,6 @@ def configure_device_groups(update_bitbar=False):
                 raise Exception('Attempting to add device(s) {} to group {}, but not configured to update bitbar config.'.format(add_device_ids, bitbar_device_group['id']))
 
         BITBAR_CACHE['device_groups'][device_group_name] = bitbar_device_group
-
-def configuration_preflight():
-    """Perform checks to ensure configuration works.
-    """
-    projects_config = CONFIG['projects']
-
-    for project_name in projects_config:
-        if project_name == 'defaults':
-            continue
-
-        project_config = projects_config[project_name]
-        file_name =  project_config.get('test_file')
-        if file_name:
-            file_path = os.path.join(FILESPATH, file_name)
-            if not os.path.exists(file_path):
-                raise ConfigurationFileException("'%s' does not exist!" % file_path)
-
-        file_name = project_config.get('application_file')
-        if file_name:
-            file_path = os.path.join(FILESPATH, file_name)
-            if not os.path.exists(file_path):
-                raise ConfigurationFileException("'%s' does not exist!" % file_path)
 
 def configure_projects(update_bitbar=False):
     """Configure projects from configuration.

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -52,7 +52,7 @@ class ConfigurationExceptionBase(Exception):
     def __init__(self, message):
         self.message = message
 
-class ConfigurationFileUploadException(ConfigurationExceptionBase):
+class ConfigurationFileException(ConfigurationExceptionBase):
     pass
 
 
@@ -83,7 +83,7 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
     try:
         configure_device_groups(update_bitbar=update_bitbar)
         configure_projects(update_bitbar=update_bitbar)
-    except ConfigurationFileUploadException as e:
+    except ConfigurationFileException as e:
         logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
         logger.error("%s: %s" % (e.__class__.__name__, e.message))
         sys.exit(1)
@@ -210,7 +210,7 @@ def configure_projects(update_bitbar=False):
                         file_path = os.path.join(FILESPATH, file_name)
                         TESTDROID.upload_test_file(bitbar_project['id'], file_path)
                     except IOError:
-                        raise ConfigurationFileUploadException("'%s' does not exist!" % file_path)
+                        raise ConfigurationFileException("'%s' does not exist!" % file_path)
                     bitbar_file = get_files(name=file_name, inputtype='test')[-1]
                 else:
                     raise Exception('Test file {} not found and not configured to update bitbar configuration!'.format(file_name))
@@ -229,7 +229,7 @@ def configure_projects(update_bitbar=False):
                         TESTDROID.upload_application_file(bitbar_project['id'],
                                                           file_path)
                     except IOError:
-                        raise ConfigurationFileUploadException("'%s' does not exist!" % file_path)
+                        raise ConfigurationFileException("'%s' does not exist!" % file_path)
                     bitbar_file = get_files(name=file_name, inputtype='application')[-1]
                 else:
                     raise Exception('Application file {} not found and not configured to update bitbar configuration!'.format(file_name))

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -177,16 +177,12 @@ def configuration_preflight():
             file_path = os.path.join(FILESPATH, file_name)
             if not os.path.exists(file_path):
                 raise ConfigurationFileException("'%s' does not exist!" % file_path)
-            else:
-                print("File exists %s" % file_path)
 
         file_name = project_config.get('application_file')
         if file_name:
             file_path = os.path.join(FILESPATH, file_name)
             if not os.path.exists(file_path):
                 raise ConfigurationFileException("'%s' does not exist!" % file_path)
-            else:
-                print("File exists %s" % file_path)
 
 def configure_projects(update_bitbar=False):
     """Configure projects from configuration.

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -225,10 +225,11 @@ def configure_projects(update_bitbar=False):
             else:
                 if update_bitbar:
                     try:
+                        file_path = os.path.join(FILESPATH, file_name)
                         TESTDROID.upload_application_file(bitbar_project['id'],
-                                                          os.path.join(FILESPATH, file_name))
+                                                          file_path)
                     except IOError:
-                        raise ConfigurationFileUploadException("'%s' does not exist!" % file_name)
+                        raise ConfigurationFileUploadException("'%s' does not exist!" % file_path)
                     bitbar_file = get_files(name=file_name, inputtype='application')[-1]
                 else:
                     raise Exception('Application file {} not found and not configured to update bitbar configuration!'.format(file_name))

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -236,10 +236,8 @@ def configure_projects(update_bitbar=False):
                 bitbar_file = bitbar_files[-1]
             else:
                 if update_bitbar:
-                    file_path = os.path.join(FILESPATH, file_name)
-                    if not os.path.exists(file_path):
-                        raise ConfigurationFileException("'%s' does not exist!" % file_path)
-                    TESTDROID.upload_test_file(bitbar_project['id'], file_path)
+                    TESTDROID.upload_test_file(bitbar_project['id'],
+                                               os.path.join(FILESPATH, file_name))
                     bitbar_file = get_files(name=file_name, inputtype='test')[-1]
                 else:
                     raise Exception('Test file {} not found and not configured to update bitbar configuration!'.format(file_name))
@@ -253,10 +251,8 @@ def configure_projects(update_bitbar=False):
                 bitbar_file = bitbar_files[-1]
             else:
                 if update_bitbar:
-                    file_path = os.path.join(FILESPATH, file_name)
-                    if not os.path.exists(file_path):
-                        raise ConfigurationFileException("'%s' does not exist!" % file_path)
-                    TESTDROID.upload_application_file(bitbar_project['id'], file_path)
+                    TESTDROID.upload_application_file(bitbar_project['id'],
+                                                      os.path.join(FILESPATH, file_name))
                     bitbar_file = get_files(name=file_name, inputtype='application')[-1]
                 else:
                     raise Exception('Application file {} not found and not configured to update bitbar configuration!'.format(file_name))


### PR DESCRIPTION
## overview

- adds a function to check that things required for configuration are present
- also pulls out configuration expansion/defaulting

## testing:

### verify that test-run-manager continues to work

- in test_run_manager.py, set TESTING=True
- run test-run-manager
  - seems to operate normally

### verify that it explodes if files are missing
```
(venv) ➜  mozilla-bitbar-devicepool git:(fix_io_error) ✗ mv files files.bak
(venv) ➜  mozilla-bitbar-devicepool git:(fix_io_error) ✗  python mozilla_bitbar_devicepool/main.py run-test --update-bitbar --project-name mozilla-docker-image-test
                MainThread INFO     configure: performing checks
                MainThread ERROR    '/Users/aerickson/git/mozilla-bitbar-devicepool/files/aerickson-empty-test.zip' does not exist!
                MainThread ERROR    Configuration files seem to be missing! Please place and restart. Exiting...
(venv) ➜  mozilla-bitbar-devicepool git:(fix_io_error) ✗
```

### verify that configuration object hasn't changed

Add following to configuration.py:configure at end and compared objects.

```python
import pprint
pprint.pprint(CONFIG['projects'])
sys.exit(1)
```

Output is the same.


## original exception:

```
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]: Traceback (most recent call last):
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 170, in <module>
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:     main()
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 167, in main
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:     args.func(args)
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 56, in test_run_manager
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:     configuration.configure(bitbar_configpath, filespath=args.files)
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/configuration.py", line 71, in configure
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:     configure_projects()
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/configuration.py", line 179, in configure_projects
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:     os.path.join(FILESPATH, file_name))
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 409, in upload_application_file
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:     return self.upload(path=path, filename=filename)
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 237, in upload
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]:     with open(filename, 'rb') as f:
Jun 09 08:52:51 bitbar-devicepool-0 bash[13116]: IOError: [Errno 2] No such file or directory: '/home/bitbar/mozilla-bitbar-devicepool/files/aerickson-Testdroid.apk'
```