### PR TITLE
test-3: use image that deletes the g-w run count file

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191017T134918
+      DOCKER_IMAGE_VERSION: 20191022T154928
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb


### PR DESCRIPTION
Use in test-3 proejct for initial testing.

See https://github.com/bclary/mozilla-bitbar-docker/pull/28 for more information.

built from https://github.com/bclary/mozilla-bitbar-docker/commit/a4e90c6180f098b620079441eabbb2b7ca82becd:
```10-22 14:27:31.516 Successfully tagged mozilla-image:20191022T154928```
