### PR TITLE
set default image to the 'gw counter fix' image

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20190917T123157
+      DOCKER_IMAGE_VERSION: 20191022T154928
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
See https://github.com/bclary/mozilla-bitbar-docker/pull/28 for more background on the image's changes.

Tests:
  - https://treeherder.mozilla.org/#/jobs?repo=try&revision=0d3f7eda20365f014c61cb80a9e382c70b3910f5