### PR TITLE
use the latest 1804 image on the test queues

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190920T121854
+      DOCKER_IMAGE_VERSION: 20191023T180043
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190920T121854
+      DOCKER_IMAGE_VERSION: 20191023T180043
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191022T154928
+      DOCKER_IMAGE_VERSION: 20191023T180043
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20190920T121854
+      DOCKER_IMAGE_VERSION: 20191023T180043
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
Have already done preliminary testing (see https://github.com/bclary/mozilla-bitbar-devicepool/pull/59 for results). This is a final round to ensure everything is still working with recent changes (including g-w counter file deletion).



built from https://github.com/bclary/mozilla-bitbar-docker/commit/26ba1cb55e0f05f43d4221e01f2833ace962c551: `10-23 15:07:01.613 Successfully tagged mozilla-image:20191023T180043`
