### PR TITLE
use new TC rootUrl, path, and docker image

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -73,42 +73,42 @@ projects:
   #   additional_parameters:
   #     DOCKER_IMAGE_VERSION: 20190528T112747
   # used for testing new docker images
-  # mozilla-gw-test-1:
-  #   device_group_name: test-1
-  #   framework_name: mozilla-usb
-  #   description: used for testing new images
-  #   additional_parameters:
-  #     TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
-  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
-  #     # replace with version to test
-  #     DOCKER_IMAGE_VERSION: 20191023T180043
-  # mozilla-gw-test-2:
-  #   device_group_name: test-2
-  #   framework_name: mozilla-usb
-  #   description: used for testing new images
-  #   additional_parameters:
-  #     TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
-  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
-  #     # replace with version to test
-  #     DOCKER_IMAGE_VERSION: 20191023T180043
-  # mozilla-gw-test-3:
-  #   device_group_name: test-3
-  #   framework_name: mozilla-usb
-  #   description: used for testing new images
-  #   additional_parameters:
-  #     TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
-  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
-  #     # replace with version to test
-  #     DOCKER_IMAGE_VERSION: 20191023T180043
-  # mozilla-docker-image-test:
-  #   device_group_name: motog5-test
-  #   framework_name: mozilla-usb
-  #   description: Mozilla Docker image test
-  #   additional_parameters:
-  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
-  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
-  #     # replace with version to test
-  #     DOCKER_IMAGE_VERSION: 20191023T180043
+  mozilla-gw-test-1:
+    device_group_name: test-1
+    framework_name: mozilla-usb
+    description: used for testing new images
+    additional_parameters:
+      TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
+      TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
+      # replace with version to test
+      DOCKER_IMAGE_VERSION: 20191023T180043
+  mozilla-gw-test-2:
+    device_group_name: test-2
+    framework_name: mozilla-usb
+    description: used for testing new images
+    additional_parameters:
+      TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
+      TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
+      # replace with version to test
+      DOCKER_IMAGE_VERSION: 20191023T180043
+  mozilla-gw-test-3:
+    device_group_name: test-3
+    framework_name: mozilla-usb
+    description: used for testing new images
+    additional_parameters:
+      TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
+      TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
+      # replace with version to test
+      DOCKER_IMAGE_VERSION: 20191023T180043
+  mozilla-docker-image-test:
+    device_group_name: motog5-test
+    framework_name: mozilla-usb
+    description: Mozilla Docker image test
+    additional_parameters:
+      TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
+      TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
+      # replace with version to test
+      DOCKER_IMAGE_VERSION: 20191023T180043
 device_groups:
   motog4-docker-builder:
     Docker Builder:

--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
 device_groups:
   motog4-docker-builder:
     Docker Builder:

--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:

--- a/mozilla_bitbar_devicepool/taskcluster.py
+++ b/mozilla_bitbar_devicepool/taskcluster.py
@@ -5,7 +5,7 @@
 import requests
 
 def get_taskcluster_pending_tasks(provisioner_id, worker_type):
-    taskcluster_queue_url = 'https://queue.taskcluster.net/v1/pending/%s/%s' % (
+    taskcluster_queue_url = 'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/pending/%s/%s' % (
         provisioner_id, worker_type)
     r = requests.get(taskcluster_queue_url)
     if r.ok:


### PR DESCRIPTION
Will be landing Nov 9 during the migration.

image created in https://github.com/bclary/mozilla-bitbar-docker/pull/29

new pattern per Dustin:
  - https://foo.taskcluster.net/v1/bar -> <rootUrl>/api/foo/v1/bar

Confirmed https://firefox-ci-tc.services.mozilla.com/api/queue/v1/pending/proj-autophone/gecko-t-bitbar-gw-perf-p2 doesn't explode.