### PR TITLE
 use new TC rootUrl, path, docker image, and only test pools

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -14,54 +14,54 @@ projects:
       DOCKER_IMAGE_VERSION: 20191029T170431
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
-  mozilla-gw-unittest-p2:
-    device_group_name: pixel2-unit-2
-    device_model: pixel2
-    framework_name: mozilla-usb
-    description: Mozilla Unit tests for Pixel2 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-p2
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-p2
-  mozilla-gw-perftest-p2:
-    device_group_name: pixel2-perf-2
-    device_model: pixel2
-    framework_name: mozilla-usb
-    description: Mozilla Performance tests for Pixel2 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-p2
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-p2
-  mozilla-gw-perftest-g5:
-    device_group_name: motog5-perf-2
-    device_model: motog5
-    framework_name: mozilla-usb
-    description: Mozilla Performance tests for MotoG5 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-g5
-  mozilla-gw-batttest-p2:
-    device_group_name: pixel2-batt-2
-    device_model: pixel2
-    framework_name: mozilla-tcp
-    description: Mozilla Battery tests for Pixel2 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-p2
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-p2
-  mozilla-gw-batttest-g5:
-    device_group_name: motog5-batt-2
-    device_model: motog5
-    framework_name: mozilla-tcp
-    description: Mozilla Battery tests for MotoG5 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-g5
-  mozilla-gw-unittest-g5:
-    device_group_name: motog5-unit-2
-    device_model: motog5
-    framework_name: mozilla-usb
-    description: Mozilla Unit tests for MotoG5 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-g5
+  # mozilla-gw-unittest-p2:
+  #   device_group_name: pixel2-unit-2
+  #   device_model: pixel2
+  #   framework_name: mozilla-usb
+  #   description: Mozilla Unit tests for Pixel2 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-p2
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-p2
+  # mozilla-gw-perftest-p2:
+  #   device_group_name: pixel2-perf-2
+  #   device_model: pixel2
+  #   framework_name: mozilla-usb
+  #   description: Mozilla Performance tests for Pixel2 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-p2
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-p2
+  # mozilla-gw-perftest-g5:
+  #   device_group_name: motog5-perf-2
+  #   device_model: motog5
+  #   framework_name: mozilla-usb
+  #   description: Mozilla Performance tests for MotoG5 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-g5
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-g5
+  # mozilla-gw-batttest-p2:
+  #   device_group_name: pixel2-batt-2
+  #   device_model: pixel2
+  #   framework_name: mozilla-tcp
+  #   description: Mozilla Battery tests for Pixel2 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-p2
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-p2
+  # mozilla-gw-batttest-g5:
+  #   device_group_name: motog5-batt-2
+  #   device_model: motog5
+  #   framework_name: mozilla-tcp
+  #   description: Mozilla Battery tests for MotoG5 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-g5
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-g5
+  # mozilla-gw-unittest-g5:
+  #   device_group_name: motog5-unit-2
+  #   device_model: motog5
+  #   framework_name: mozilla-usb
+  #   description: Mozilla Unit tests for MotoG5 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-g5
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-g5
   # used for building new docker images
   # mozilla-docker-build:
   #   device_group_name: motog4-docker-builder

--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20191029T170431
+      DOCKER_IMAGE_VERSION: 20191023T180043
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   # mozilla-gw-unittest-p2:
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
 device_groups:
   motog4-docker-builder:
     Docker Builder:

--- a/config/config.yml
+++ b/config/config.yml
@@ -105,7 +105,7 @@ projects:
     framework_name: mozilla-usb
     description: Mozilla Docker image test
     additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-test-g5
+      TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
       DOCKER_IMAGE_VERSION: 20191029T170431

--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20191023T180043
+      DOCKER_IMAGE_VERSION: 20191029T170431
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:

--- a/mozilla_bitbar_devicepool/taskcluster.py
+++ b/mozilla_bitbar_devicepool/taskcluster.py
@@ -5,7 +5,7 @@
 import requests
 
 def get_taskcluster_pending_tasks(provisioner_id, worker_type):
-    taskcluster_queue_url = 'https://queue.taskcluster.net/v1/pending/%s/%s' % (
+    taskcluster_queue_url = 'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/pending/%s/%s' % (
         provisioner_id, worker_type)
     r = requests.get(taskcluster_queue_url)
     if r.ok:


### PR DESCRIPTION
note: based off of https://github.com/bclary/mozilla-bitbar-devicepool/pull/67

image created in https://github.com/bclary/mozilla-bitbar-docker/pull/29

Will be used to test out the new cluster before the switchover. 

DO NOT LAND. testing only.