### PR TITLE
add 7 hosts from p2-perf to p2-unit

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -187,8 +187,6 @@ device_groups:
     pixel2-20:
     pixel2-21:
     pixel2-22:
-  pixel2-perf:
-  pixel2-perf-2:
     pixel2-23:
     pixel2-24:
     pixel2-25:
@@ -196,6 +194,8 @@ device_groups:
     pixel2-27:
     pixel2-28:
     pixel2-29:
+  pixel2-perf:
+  pixel2-perf-2:
     pixel2-30:
     pixel2-31:
     pixel2-32:


### PR DESCRIPTION
https://earthangel-b40313e5.influxcloud.net/d/wIJoZ4HWk/android-queues?orgId=1&from=now-30d&to=now&fullscreen&panelId=6
- The load on the p2-unit queue has gone up significantly. We have idle p2-perf devices. 

https://earthangel-b40313e5.influxcloud.net/d/Vl6mKHbWz/android-hw-lag?orgId=1&refresh=2h&var-workertype=All&from=now-7d&to=now
- The lag on p2-unit queues is much higher than p2-perf.

Move 7 p2-perf devices to p2-unit.