### PR TITLE
set the default image to 20191209T170558

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20191029T170431
+      DOCKER_IMAGE_VERSION: 20191209T170558
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
built and tested in https://github.com/bclary/mozilla-bitbar-docker/pull/34