### PR TITLE
catch ConnectionErrors thrown in thread_active_jobs

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -165,7 +165,13 @@ class TestRunManager(object):
     def thread_active_jobs(self):
         while self.state == 'RUNNING':
             logger.info('getting active runs')
-            self.process_active_runs()
+            try:
+                self.process_active_runs()
+            except requests.exceptions.ConnectionError as e:
+                logger.warning("exception raised when calling process_active_runs.")
+                logger.warning(e)
+                # TODO: if we see this a lot, add exponential backoff?
+                time.sleep(10)
             time.sleep(10)
 
     def process_active_runs(self):


### PR DESCRIPTION
Caused the service to stop processing today for a few hours.

This failure is particularly nasty because my devicepool-health script looks for 'RUNNING' tasks as a sign of health. Because this call updates those metrics, it thought everything was fine. The 'low device health alert' finally fired.

```
Dec 12 14:11:36 bitbar-devicepool-0 bash[11668]:                 MainThread WARNING  exception raised when calling get_bitbar_test_stats.
Dec 12 14:11:36 bitbar-devicepool-0 bash[11668]:                 MainThread WARNING  HTTPSConnectionPool(host='mozilla.testdroid.com', port=443): Max retries exceeded with url: /api/v2/device-groups/54/devices?limit=0 (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fc271847290>: Failed to establish a new connection: [Errno 110] Connection timed out',))
...
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]: Traceback (most recent call last):
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     self.run()
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/usr/lib/python2.7/threading.py", line 754, in run
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     self.__target(*self.__args, **self.__kwargs)
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 168, in thread_active_jobs
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     self.process_active_runs()
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 181, in process_active_runs
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     result = get_active_test_runs()
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 102, in get_active_test_runs
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     response = TESTDROID.get('/api/v2/admin/runs?filter=d_endTime_isnull&limit=0')
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 254, in get
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     res =  requests.get(url, params=payload, headers=headers)
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/requests/api.py", line 75, in get
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     return request('get', url, params=params, **kwargs)
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/requests/api.py", line 60, in request
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     return session.request(method=method, url=url, **kwargs)
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/requests/sessions.py", line 533, in request
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     resp = self.send(prep, **send_kwargs)
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/requests/sessions.py", line 646, in send
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     r = adapter.send(request, **kwargs)
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/requests/adapters.py", line 516, in send
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]:     raise ConnectionError(e, request=request)
Dec 12 14:15:18 bitbar-devicepool-0 bash[11668]: ConnectionError: HTTPSConnectionPool(host='mozilla.testdroid.com', port=443): Max retries exceeded with url: /api/v2/admin/runs?filter=d_endTime_isnull&limit=0 (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fc271f42c10>: Failed to establish a new connection: [Errno 110] Connection timed out',))
```