### PR TITLE
use 20191216T152458 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20191209T170558
+      DOCKER_IMAGE_VERSION: 20191216T152458
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
PR to set it as the image for testing: https://github.com/bclary/mozilla-bitbar-devicepool/pull/80

p2 tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=d4b2fc5a520195a75677a49a05efa9c347fb6ff5

g5 tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=bafe5cd98220628852ad243772cc5436575e354c