### PR TITLE
move 7 p2-perf devices to p2-unit

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -194,8 +194,6 @@ device_groups:
     pixel2-27:
     pixel2-28:
     pixel2-29:
-  pixel2-perf:
-  pixel2-perf-2:
     pixel2-30:
     pixel2-31:
     pixel2-32:
@@ -203,6 +201,8 @@ device_groups:
     pixel2-36:
     pixel2-37:
     pixel2-38:
+  pixel2-perf:
+  pixel2-perf-2:
     pixel2-39:
     pixel2-40:
     pixel2-41:


### PR DESCRIPTION
The p2-unit queue has been backlogged for 24+ hours (p2-perf is empty).

Move 7 devices to the p2-unit queue.

With this change:
```
motog5-batt-2: 2
motog5-perf-2: 36
motog5-unit-2: 0
pixel2-batt-2: 2
pixel2-perf-2: 21
pixel2-unit-2: 35
```