### PR TITLE
use 20191217T130011 in the test queues

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191216T152458
+      DOCKER_IMAGE_VERSION: 20191217T130011
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191216T152458
+      DOCKER_IMAGE_VERSION: 20191217T130011
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191216T152458
+      DOCKER_IMAGE_VERSION: 20191217T130011
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191216T152458
+      DOCKER_IMAGE_VERSION: 20191217T130011
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
built from https://github.com/bclary/mozilla-bitbar-docker/ at f879861
- `12-17 13:23:26.190 Successfully tagged mozilla-image:20191217T130011`
  - https://mozilla.testdroid.com/#testing/device-session/1328436/1516110/39904259

includes 3 changes from the currently live image:
- https://github.com/bclary/mozilla-bitbar-docker/pull/32
- https://github.com/bclary/mozilla-bitbar-docker/pull/33
- https://github.com/bclary/mozilla-bitbar-docker/pull/36

Previously built image (https://github.com/bclary/mozilla-bitbar-devicepool/pull/83) didn't fix livelogging.
