### PR TITLE
use 20191217T130011 as the default image

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20191209T170558
+      DOCKER_IMAGE_VERSION: 20191217T130011
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
description of changes: https://github.com/bclary/mozilla-bitbar-devicepool/pull/83

- p2 tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=aa3de5148e5c63cbc6a6975c486a5cf3ce58fb8c
  - all but 2 passing, failures not related to script.py
- g5 tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=9b583ca6d0f89ca6400d380f6d95b6a799b66e04
  - all passing
