### PR TITLE
when running a single job, mention that it's been started

### DIFF
--- a/mozilla_bitbar_devicepool/main.py
+++ b/mozilla_bitbar_devicepool/main.py
@@ -69,7 +69,6 @@ def run_test(args):
         bitbar_configpath = args.bitbar_config
 
     configuration.configure(bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar)
-s
     run_test_for_project(args.project_name)
     logger.info("run started for project '%s'" % args.project_name)
 

--- a/mozilla_bitbar_devicepool/main.py
+++ b/mozilla_bitbar_devicepool/main.py
@@ -69,8 +69,9 @@ def run_test(args):
         bitbar_configpath = args.bitbar_config
 
     configuration.configure(bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar)
-
+s
     run_test_for_project(args.project_name)
+    logger.info("run started for project '%s'" % args.project_name)
 
 def main():
 

--- a/mozilla_bitbar_devicepool/main.py
+++ b/mozilla_bitbar_devicepool/main.py
@@ -69,6 +69,7 @@ def run_test(args):
         bitbar_configpath = args.bitbar_config
 
     configuration.configure(bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar)
+
     run_test_for_project(args.project_name)
     logger.info("run started for project '%s'" % args.project_name)
 


### PR DESCRIPTION
When executing 'run-test', the only output is the configuration. 

Mention when the job has been started.