### PR TITLE
use 20191220T130650 in test queues

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191217T130011
+      DOCKER_IMAGE_VERSION: 20191220T130650
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191217T130011
+      DOCKER_IMAGE_VERSION: 20191220T130650
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191217T130011
+      DOCKER_IMAGE_VERSION: 20191220T130650
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20191217T130011
+      DOCKER_IMAGE_VERSION: 20191220T130650
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
Includes two changes from current live:

- https://github.com/bclary/mozilla-bitbar-docker/pull/37
- https://github.com/bclary/mozilla-bitbar-docker/pull/38

build: https://mozilla.testdroid.com/#testing/test-run/1328436/1529533
  - `12-20 11:10:14.171 Successfully tagged mozilla-image:20191220T130650`