### PR TITLE
use 20191220T130650 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20191217T130011
+      DOCKER_IMAGE_VERSION: 20191220T130650
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
### overview

changes included metioned in: https://github.com/bclary/mozilla-bitbar-devicepool/pull/86

### round 1
p2 tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=de75de646ed8ae577f1ea1bbe74ecf3cdf314294

g5 tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=84443f79383dac1cc891b6706240f6acc844be8a

### round 2

p2 tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=37636e1fb07ae806b78c87deda3a3028743e8137
- no failures related to the docker image

g5 tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=d630adf54c48e2b6b4ad0f244175a7bb9f89ca97
- no failures related to the docker image