### PR TITLE
exit if project not found

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -150,7 +150,7 @@ class TestRunManager(object):
                         logger.error("Test files have been archived. Exiting so configuration is rerun...")
                         logger.error("%s: %s" % (e.__class__.__name__, e.message))
                         self.state = 'STOP'
-                    elif e.statu_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, e.message):
+                    elif e.status_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, e.message):
                         logger.error("Project does not exist!. Exiting so configuration is rerun...")
                         logger.error("%s: %s" % (e.__class__.__name__, e.message))
                         self.state = 'STOP'

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -28,6 +28,7 @@ TESTING = False
 CACHE = None
 CONFIG = None
 ARCHIVED_FILE_REGEX = r'FileEntity with id [\d]* does not exist'
+PROJECT_DOES_NOT_EXIST_REGEX = r'Project with id [\d]* does not exist'
 
 
 class TestRunManager(object):
@@ -147,6 +148,10 @@ class TestRunManager(object):
                 except RequestResponseError as e:
                     if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, e.message):
                         logger.error("Test files have been archived. Exiting so configuration is rerun...")
+                        logger.error("%s: %s" % (e.__class__.__name__, e.message))
+                        self.state = 'STOP'
+                    elif e.statu_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, e.message):
+                        logger.error("Project does not exist!. Exiting so configuration is rerun...")
                         logger.error("%s: %s" % (e.__class__.__name__, e.message))
                         self.state = 'STOP'
                     else:


### PR DESCRIPTION
Fix exception when a project gets archived and devicepool can't find the project.

exception seen:

```
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:     headers={'Content-type': 'application/json', 'Accept': 'application/json'})
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 270, in post
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:     raise RequestResponseError(res.text, res.status_code)
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]: RequestResponseError: Request Error: code 404: {"message":"Project with id 934816 does not exist","statusCode":404}
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:  mozilla-docker-image-test ERROR    Failed to create test run for group motog5-test (RequestResponseError: Request Error: code 404: {"message":"Project with id 934816 does not exist","statusCode":404}).
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]: Traceback (most recent call last):
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 134, in handle_queue
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:     test_run = run_test_for_project(project_name)
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 75, in run_test_for_project
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:     return run_test_with_configuration(test_configuration)
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 25, in run_test_with_configuration
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:     headers={'Content-type': 'application/json', 'Accept': 'application/json'})
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 270, in post
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]:     raise RequestResponseError(res.text, res.status_code)
Sep 09 17:54:47 bitbar-devicepool-0 bash[11800]: RequestResponseError: Request Error: code 404: {"message":"Project with id 934816 does not exist","statusCode":404}
Sep 09 17:54:48 bitbar-devicepool-0 bash[11800]:          mozilla-gw-test-1 INFO     COUNT 1 IDLE 0 OFFLINE 0 DISABLED 0 RUNNING 1 WAITING 3 PENDING 169 STARTING 0
Sep 09 17:54:55 bitbar-devicepool-0 bash[11800]:                active_jobs INFO     getting active runs
Sep 09 17:54:58 bitbar-devicepool-0 bash[11800]:     mozilla-gw-perftest-g5 INFO     COUNT 36 IDLE 30 OFFLINE 0 DISABLED 0 RUNNING 6 WAITING 0 PENDING 0 STARTING 0
Sep 09 17:55:04 bitbar-devicepool-0 bash[11800]:     mozilla-gw-perftest-p2 INFO     COUNT 35 IDLE 1 OFFLINE 0 DISABLED 0 RUNNING 34 WAITING 4 PENDING 294 STARTING 0
Sep 09 17:55:05 bitbar-devicepool-0 bash[11800]:                active_jobs INFO     getting active runs
Sep 09 17:55:05 bitbar-devicepool-0 bash[11800]:          mozilla-gw-test-2 INFO     COUNT 1 IDLE 1 OFFLINE 0 DISABLED 0 RUNNING 0 WAITING 4 PENDING 228 STARTING 0
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:     mozilla-gw-unittest-p2 INFO     COUNT 21 IDLE 2 OFFLINE 0 DISABLED 0 RUNNING 19 WAITING 3 PENDING 40 STARTING 1
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:  mozilla-docker-image-test ERROR    Failed to create test run for group motog5-test (RequestResponseError: Request Error: code 404: {"message":"Project with id 934816 does not exist","statusCode":404}).
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]: Traceback (most recent call last):
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 134, in handle_queue
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:     test_run = run_test_for_project(project_name)
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 75, in run_test_for_project
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:     return run_test_with_configuration(test_configuration)
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 25, in run_test_with_configuration
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:     headers={'Content-type': 'application/json', 'Accept': 'application/json'})
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 270, in post
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]:     raise RequestResponseError(res.text, res.status_code)
Sep 09 17:55:07 bitbar-devicepool-0 bash[11800]: RequestResponseError: Request Error: code 404: {"message":"Project with id 934816 does not exist","statusCode":404}
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:  mozilla-docker-image-test ERROR    Failed to create test run for group motog5-test (RequestResponseError: Request Error: code 404: {"message":"Project with id 934816 does not exist","statusCode":404}).
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]: Traceback (most recent call last):
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 134, in handle_queue
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:     test_run = run_test_for_project(project_name)
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 75, in run_test_for_project
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:     return run_test_with_configuration(test_configuration)
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 25, in run_test_with_configuration
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:     headers={'Content-type': 'application/json', 'Accept': 'application/json'})
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 270, in post
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:     raise RequestResponseError(res.text, res.status_code)
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]: RequestResponseError: Request Error: code 404: {"message":"Project with id 934816 does not exist","statusCode":404}
Sep 09 17:55:08 bitbar-devicepool-0 bash[11800]:     mozilla-gw-unittest-p2 INFO     test run 1081267 started
Sep 09 17:55:09 bitbar-devicepool-0 bash[11800]:          mozilla-gw-test-1 INFO     COUNT 1 IDLE 0 OFFLINE 0 DISABLED 0 RUNNING 1 WAITING 3 PENDING 169 STARTING 0
Sep 09 17:55:12 bitbar-devicepool-0 bash[11800]:                 MainThread INFO     getting stats for all projects
Sep 09 17:55:18 bitbar-devicepool-0 bash[11800]:     mozilla-gw-perftest-g5 INFO     thread exiting
Sep 09 17:55:23 bitbar-devicepool-0 bash[11800]:     mozilla-gw-batttest-g5 INFO     thread exiting
```