### PR TITLE
if duplicate projects, notify user and exit

### DIFF
--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -57,6 +57,10 @@ class ConfigurationFileException(ConfigurationException):
     pass
 
 
+class DuplicateProjectException(ConfigurationException):
+    pass
+
+
 def get_filespath():
     """Return files path where application and test files are kept.
     """
@@ -226,7 +230,7 @@ def configure_projects(update_bitbar=False):
         project_config = projects_config[project_name]
         bitbar_projects = get_projects(name=project_name)
         if len(bitbar_projects) > 1:
-            raise Exception('project {} has {} duplicates'.format(project_name, len(bitbar_projects) - 1))
+            raise DuplicateProjectException('project {} has {} duplicates'.format(project_name, len(bitbar_projects) - 1))
         elif len(bitbar_projects) == 1:
             bitbar_project = bitbar_projects[0]
         else:

--- a/mozilla_bitbar_devicepool/main.py
+++ b/mozilla_bitbar_devicepool/main.py
@@ -52,7 +52,12 @@ def test_run_manager(args):
     else:
         bitbar_configpath = args.bitbar_config
 
-    configuration.configure(bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar)
+    try:
+        configuration.configure(bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar)
+    except configuration.DuplicateProjectException as e:
+        logger.error("Duplicate project found! Please archive all but one and restart. Exiting...")
+        logger.error(e)
+        sys.exit(1)
 
     manager = TestRunManager(wait=args.wait)
     manager.run()


### PR DESCRIPTION
see https://bugzilla.mozilla.org/show_bug.cgi?id=1566230

example exception:

```
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]: Traceback (most recent call last):
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 170, in <module>
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:     main()
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 167, in main
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:     args.func(args)
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/main.py", line 55, in test_run_manager
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:     configuration.configure(bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar)
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/configuration.py", line 74, in configure
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:     configure_projects(update_bitbar=update_bitbar)
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/configuration.py", line 174, in configure_projects
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]:     raise Exception('project {} has {} duplicates'.format(project_name, len(bitbar_projects) - 1))
Jul 15 21:48:19 bitbar-devicepool-0 bash[26376]: Exception: project mozilla-gw-unittest-g5 has 1 duplicates
```