### PR TITLE
use 20200109T131803 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20191220T130650
+      DOCKER_IMAGE_VERSION: 20200109T131803
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
see https://github.com/bclary/mozilla-bitbar-devicepool/pull/90 for details on contents

tests:
  - g5: https://treeherder.mozilla.org/#/jobs?repo=try&revision=0e027f5a935a6e95dd58116573fda46f455d1ba2
    - no failures related to mozharness
  - p2: https://treeherder.mozilla.org/#/jobs?repo=try&revision=92bdfa3d185fb9f7a60848be459fe9be4b0c71ab
    - no failures related to mozharness