### PR TITLE
use 20200116T163912 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20200109T131803
+      DOCKER_IMAGE_VERSION: 20200116T163912
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
see https://github.com/bclary/mozilla-bitbar-devicepool/pull/92 for details on contents

tests:
  - https://treeherder.mozilla.org/#/jobs?repo=try&revision=57960c02ebe35b433080deaa0805c6172ac5faff