### PR TITLE
service file: always restart the service, not just on failure

### DIFF
--- a/service/bitbar.service
+++ b/service/bitbar.service
@@ -5,7 +5,7 @@ Description=Bitbar Testrun manager service
 Type=simple
 ExecStart=/bin/bash /home/bitbar/mozilla-bitbar-devicepool/bin/start_android_hardware_testing.sh
 ExecStop=/bin/bash /home/bitbar/mozilla-bitbar-devicepool/bin/stop_android_hardware_testing.sh
-Restart=on-failure
+Restart=always
 WorkingDirectory=/home/bitbar/mozilla-bitbar-devicepool
 User=bitbar
 


### PR DESCRIPTION
A recent change to handle missing projects (https://github.com/bclary/mozilla-bitbar-devicepool/pull/88) cause the service to exit cleanly with a warning message. Systemd won't restart the process in this state currently. Fix that.

Tested on devicepool0.