### PR TITLE
use 20200206T114002 in test queues

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200116T163912
+      DOCKER_IMAGE_VERSION: 20200206T114002
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200116T163912
+      DOCKER_IMAGE_VERSION: 20200206T114002
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200116T163912
+      DOCKER_IMAGE_VERSION: 20200206T114002
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200116T163912
+      DOCKER_IMAGE_VERSION: 20200206T114002
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
Reviving this PR per discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1611936.

Built from https://github.com/bclary/mozilla-bitbar-docker/pull/35 @ 45836a895c98317af895ecd8d3e4b507204ba8ab.

https://mozilla.testdroid.com/#testing/device-session/1613876/1684526/45037066: 
`02-06 11:44:48.867 Successfully tagged mozilla-image:20200206T114002`