### PR TITLE
use 20200221T180700 in test queues

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200213T173833
+      DOCKER_IMAGE_VERSION: 20200221T180700
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200213T173833
+      DOCKER_IMAGE_VERSION: 20200221T180700
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200213T173833
+      DOCKER_IMAGE_VERSION: 20200221T180700
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200213T173833
+      DOCKER_IMAGE_VERSION: 20200221T180700
 device_groups:
   motog4-docker-builder:
     Docker Builder:


### PR DESCRIPTION
built from https://github.com/bclary/mozilla-bitbar-docker/commit/0ca7b1fafce45410d45cf9a652b3fd7d9ae5416a

includes https://github.com/bclary/mozilla-bitbar-docker/pull/44

https://mozilla.testdroid.com/#testing/device-session/1613876/1739777/46715433
> 02-21 18:13:03.184 Successfully tagged mozilla-image:20200221T180700
