### PR TITLE
use 20200221T180700 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20200213T173833
+      DOCKER_IMAGE_VERSION: 20200221T180700
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
includes: https://github.com/bclary/mozilla-bitbar-docker/pull/44

tests:
  - `./mach try fuzzy --artifact  --full --query "'android-hw \!power \!nightly \!pgo '-1-" --query "'android-hw-p2 'pgo-geckoview-jsreftest-e10s" --no-push`
    - https://treeherder.mozilla.org/#/jobs?repo=try&revision=a5b8f4428ca797c04312f3f717d7477087ec950b