### PR TITLE
catch RequestResponseErrors in process_active_runs()

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -188,8 +188,14 @@ class TestRunManager(object):
         for project_name in bitbar_projects:
             accumulation_dict[project_name] = []
 
-        # gather all runs per project
-        result = get_active_test_runs()
+        try:
+            # gather all runs per project
+            result = get_active_test_runs()
+        except RequestResponseError as e:
+            logger.error("process_active_runs: RequestResponseError received")
+            logger.error(e)
+            return
+
         for item in result:
             project_name = item['projectName']
             # only accumulate for projects in our config


### PR DESCRIPTION
Caused a service outage on 3/5. Bitbar had some RDS issues that threw lots of error in devicepool's requests to the bitbar API.

```
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]: Exception in thread active_jobs:
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]: Traceback (most recent call last):
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:   File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:     self.run()
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:   File "/usr/lib/python2.7/threading.py", line 754, in run
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:     self.__target(*self.__args, **self.__kwargs)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 174, in thread_active_jobs
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:     self.process_active_runs()
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 192, in process_active_runs
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:     result = get_active_test_runs()
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 102, in get_active_test_runs
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:     response = TESTDROID.get('/api/v2/admin/runs?filter=d_endTime_isnull&limit=0')
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/local/lib/python2.7/site-packages/testdroid/__init__.py", line 256, in get
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:     raise RequestResponseError(res.text, res.status_code)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]: RequestResponseError: Request Error: code 500: <!DOCTYPE html><html><head><title>Apache Tomcat/8.5.9 - Error report</title><style type="text/css">h1 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;} h2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;} h3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;} body {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;} b {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;} p {font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;} a {color:black;} a.name {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style> </head><body><h1>HTTP Status 500 - Unable to acquire JDBC Connection; nested exception is org.hibernate.exception.GenericJDBCException: Unable to acquire JDBC Connection</h1><div class="line"></div><p><b>type</b> Exception report</p><p><b>message</b> <u>Unable to acquire JDBC Connection; nested exception is org.hibernate.exception.GenericJDBCException: Unable to acquire JDBC Connection</u></p><p><b>description</b> <u>The server encountered an internal error that prevented it from fulfilling this request.</u></p><p><b>exception</b></p><pre>org.springframework.orm.jpa.JpaSystemException: Unable to acquire JDBC Connection; nested exception is org.hibernate.exception.GenericJDBCException: Unable to acquire JDBC Connection
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         org.springframework.orm.jpa.vendor.HibernateJpaDialect.convertHibernateAccessException(HibernateJpaDialect.java:314)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         org.springframework.orm.jpa.vendor.HibernateJpaDialect.translateExceptionIfPossible(HibernateJpaDialect.java:225)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.translateExceptionIfPossible(AbstractEntityManagerFactoryBean.java:527)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         org.springframework.dao.support.ChainedPersistenceExceptionTranslator.translateExceptionIfPossible(ChainedPersistenceExceptionTranslator.java:61)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         org.springframework.dao.support.DataAccessUtils.translateIfNecessary(DataAccessUtils.java:242)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:153)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:185)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:688)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         com.testdroid.dao.UserDao$$EnhancerBySpringCGLIB$$5f56e0df.loadByAPIkey(&lt;generated&gt;)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         com.testdroid.cloud.authentication.CustomAuthenticationProvider.authenticate(CustomAuthenticationProvider.java:26)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         org.springframework.security.authentication.ProviderManager.authenticate(ProviderManager.java:174)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         sun.reflect.GeneratedMethodAccessor484.invoke(Unknown Source)
Mar 06 00:25:23 bitbar-devicepool-0 bash[32642]:         sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
...
```