### PR TITLE
move p2-perf devices to p2-unit

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -195,8 +195,6 @@ device_groups:
     pixel2-25:
     pixel2-26:
     pixel2-27:
-  pixel2-perf:
-  pixel2-perf-2:
     pixel2-28:
     pixel2-29:
     pixel2-30:
@@ -206,6 +204,8 @@ device_groups:
     pixel2-34:
     pixel2-35:
     pixel2-36:
+  pixel2-perf:
+  pixel2-perf-2:
     pixel2-37:
     pixel2-38:
     pixel2-39:


### PR DESCRIPTION
I overestimated the p2-perf load, now we're backlogged on p2-unit.

Basically pre-#102, but with the previous batt devices moved to perf queues.

current:

```
/// g-w ///
motog5-batt-2: 0
motog5-perf-2: 38
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 32
pixel2-unit-2: 26
/// test ///
motog5-test: 1
test-1: 1
test-2: 1
test-3: 1
```

new:

```
/// g-w ///
motog5-batt-2: 0
motog5-perf-2: 38
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 23
pixel2-unit-2: 35
/// test ///
motog5-test: 1
test-1: 1
test-2: 1
test-3: 1
```