### PR TITLE
move motog5-40 to motog5-unit-2

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -153,9 +153,9 @@ device_groups:
     motog5-37:
     motog5-38:
     motog5-39:
-    motog5-40:
   motog5-unit:
   motog5-unit-2:
+    motog5-40:
   motog5-test:
     # pixel2-60 has android 9.0 on it
     pixel2-60:


### PR DESCRIPTION
Requested by BC.

old:

```
/// g-w ///
motog5-batt-2: 0
motog5-perf-2: 38
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 23
pixel2-unit-2: 35
/// test ///
motog5-test: 1
test-1: 1
test-2: 1
test-3: 1
```

new:

```
/// g-w ///
motog5-batt-2: 0
motog5-perf-2: 37
motog5-unit-2: 1
pixel2-batt-2: 0
pixel2-perf-2: 23
pixel2-unit-2: 35
/// test ///
motog5-test: 1
test-1: 1
test-2: 1
test-3: 1
```