### PR TITLE
adjust jobs to start formula

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import math
 import re
 import signal
 import threading

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -110,7 +110,7 @@ class TestRunManager(object):
                 # warning: only take the log of positive non-zero numbers, or a
                 # "ValueError: math domain error" will be raised
                 jobs_to_start = min(pending_tasks,
-                                    stats['IDLE'] - stats['WAITING'] + 1 + int(math.log10(1 + pending_tasks)))
+                                    stats['IDLE'] - stats['WAITING'])
                 if jobs_to_start < 0:
                     jobs_to_start = 0
 


### PR DESCRIPTION
We've noticed we have lots of g-w runs where the worker fails to get a job. Try to reduce the number of these runs.