### PR TITLE
use 20200326T142021 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20200221T180700
+      DOCKER_IMAGE_VERSION: 20200326T142021
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200221T180700
+      DOCKER_IMAGE_VERSION: 20200326T142021
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200221T180700
+      DOCKER_IMAGE_VERSION: 20200326T142021
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -99,7 +99,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200221T180700
+      DOCKER_IMAGE_VERSION: 20200326T142021
   mozilla-docker-image-test:
     device_group_name: motog5-test
     framework_name: mozilla-usb
@@ -108,7 +108,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200221T180700
+      DOCKER_IMAGE_VERSION: 20200326T142021
 # devices hooked up to battery hubs
 #   - pixel2-34, pixel2-35. motog5-08, motog5-15.
 device_groups:


### PR DESCRIPTION
Contains only https://github.com/bclary/mozilla-bitbar-docker/pull/46.

> 03-26 15:49:31.208 Successfully tagged mozilla-image:20200326T142021
