### PR TITLE
Revert "adjust jobs to start formula (#107)"

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import math
 import re
 import signal
 import threading
@@ -109,7 +110,7 @@ class TestRunManager(object):
                 # warning: only take the log of positive non-zero numbers, or a
                 # "ValueError: math domain error" will be raised
                 jobs_to_start = min(pending_tasks,
-                                    stats['IDLE'] - stats['WAITING'])
+                                    stats['IDLE'] - stats['WAITING'] + 1 + int(math.log10(1 + pending_tasks)))
                 if jobs_to_start < 0:
                     jobs_to_start = 0
 


### PR DESCRIPTION
#107 was an attempt to reduce the number of jobs that were ending without servicing jobs. We've now achieved that via another means (https://github.com/bclary/mozilla-bitbar-docker/pull/46).

The code we're putting back in starts a few extra bitbar runs for busy queues (that helps us drive higher utilization/throughput).