### PR TITLE
move 10 p2-perf devices to p2-unit

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -204,8 +204,6 @@ device_groups:
     pixel2-34:
     pixel2-35:
     pixel2-36:
-  pixel2-perf:
-  pixel2-perf-2:
     pixel2-37:
     pixel2-38:
     pixel2-39:
@@ -216,6 +214,8 @@ device_groups:
     pixel2-44:
     pixel2-45:
     pixel2-46:
+  pixel2-perf:
+  pixel2-perf-2:
     pixel2-47:
     pixel2-48:
     pixel2-49:


### PR DESCRIPTION
We've had a backlog for several days on p2-unit. p2-perf seems pretty dead.

current:

```
motog5-batt-2: 0
motog5-perf-2: 38
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 23
pixel2-unit-2: 35
```

after this pr:

```
motog5-batt-2: 0
motog5-perf-2: 38
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 13
pixel2-unit-2: 45
```