### PR TITLE
device_group_report: show count of device types across all pools

### DIFF
--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -57,9 +57,9 @@ class DeviceGroupReport:
     def main(self):
         self.get_report_dict()
 
-        print("/// tc-w  workers ///")
-        for key in sorted(self.tcw_result_dict.keys()):
-            print("%s: %s" % (key, self.tcw_result_dict[key]))
+        # print("/// tc-w  workers ///")
+        # for key in sorted(self.tcw_result_dict.keys()):
+        #     print("%s: %s" % (key, self.tcw_result_dict[key]))
         print("/// g-w workers ///")
         for key in sorted(self.gw_result_dict.keys()):
             print("%s: %s" % (key, self.gw_result_dict[key]))

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -67,6 +67,8 @@ class DeviceGroupReport:
         for key in sorted(self.test_result_dict.keys()):
             print("%s: %s" % (key, self.test_result_dict[key]))
         print("/// device summary ///")
+        total_count = 0
         for item in self.device_dict:
+            total_count += int(self.device_dict[item])
             print("%s: %s" % (item, self.device_dict[item]))
-
+        print("total: %s" % total_count)

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import yaml
 import os
@@ -17,6 +17,7 @@ class DeviceGroupReport:
         self.gw_result_dict = {}
         self.tcw_result_dict = {}
         self.test_result_dict = {}
+        self.device_dict = {}  # device types to count
         if not config_path:
             pathname = os.path.dirname(sys.argv[0])
             root_dir = os.path.abspath(os.path.join(pathname, ".."))
@@ -43,15 +44,29 @@ class DeviceGroupReport:
                 else:
                     self.tcw_result_dict[group] = get_len(the_item)
 
+        for group in conf_yaml["device_groups"]:
+            the_item = conf_yaml["device_groups"][group]
+            # print(the_item)
+            if the_item:
+                for device in the_item:
+                    if 'pixel2' in device:
+                        self.device_dict['p2'] = self.device_dict.get('p2', 0) + 1
+                    if 'motog5' in device:
+                        self.device_dict['g5'] = self.device_dict.get('g5', 0) + 1
+
     def main(self):
         self.get_report_dict()
 
-        print("/// tc-w ///")
+        print("/// tc-w  workers ///")
         for key in sorted(self.tcw_result_dict.keys()):
             print("%s: %s" % (key, self.tcw_result_dict[key]))
-        print("/// g-w ///")
+        print("/// g-w workers ///")
         for key in sorted(self.gw_result_dict.keys()):
             print("%s: %s" % (key, self.gw_result_dict[key]))
-        print("/// test ///")
+        print("/// test workers ///")
         for key in sorted(self.test_result_dict.keys()):
             print("%s: %s" % (key, self.test_result_dict[key]))
+        print("/// device summary ///")
+        for item in self.device_dict:
+            print("%s: %s" % (item, self.device_dict[item]))
+


### PR DESCRIPTION
Also:
- don't show tcw workers any more
- show device total
- switch this binary to py3

new output:

```
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 29
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 9
pixel2-unit-2: 44
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
p2: 54
g5: 30
total: 84
```