### PR TITLE
move 3 p2-unit devices to p2-perf

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -216,11 +216,11 @@ device_groups:
     pixel2-45:
     pixel2-46:
     pixel2-47:
+  pixel2-perf:
+  pixel2-perf-2:
     pixel2-48:
     pixel2-49:
     pixel2-50:
-  pixel2-perf:
-  pixel2-perf-2:
     pixel2-51:
     pixel2-52:
     pixel2-53:


### PR DESCRIPTION
We're currently 8 hours behind on p2-perf queues. Move 3 devices.

before:
```
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 29
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 9
pixel2-unit-2: 44
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 30
p2: 54
total: 84
```

after:

```
Using config file at '/Users/aerickson/git/mozilla-bitbar-devicepool/config/config.yml'.
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 29
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 12
pixel2-unit-2: 41
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 30
p2: 54
total: 84
```