### PR TITLE
replace pixel2-52

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -180,7 +180,7 @@ device_groups:
     # pixel2-09:
     # pixel2-10:
     # pixel2-11:
-    # pixel2-12:
+    pixel2-12:
     pixel2-13:
     pixel2-14:
     pixel2-15:
@@ -217,12 +217,12 @@ device_groups:
     pixel2-46:
     pixel2-47:
     pixel2-48:
-    pixel2-49:
   pixel2-perf:
   pixel2-perf-2:
+    pixel2-49:
     pixel2-50:
     pixel2-51:
-    pixel2-52:
+    # pixel2-52: # removed from cluster due to battery bloat
     pixel2-53:
     pixel2-54:
     pixel2-55:


### PR DESCRIPTION
It has been pulled from the cluster due to battery bloat. Replace it with a host that we've deactivated as part of the cluster size reduction.

before:
```
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 26
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 10
pixel2-unit-2: 37
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 27
p2: 48
total: 75
```


after:
```
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 26
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 10
pixel2-unit-2: 37
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 27
p2: 48
total: 75
```