### PR TITLE
create new builder device group

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -64,7 +64,7 @@ projects:
       TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-g5
   # used for building new docker images
   # mozilla-docker-build:
-  #   device_group_name: motog4-docker-builder
+  #   device_group_name: motog4-docker-builder-2
   #   device_model: motog4
   #   framework_name: Docker image build
   #   description: Mozilla Docker image build
@@ -112,7 +112,7 @@ projects:
 # devices hooked up to battery hubs
 #   - pixel2-34, pixel2-35. motog5-08, motog5-15.
 device_groups:
-  motog4-docker-builder:
+  motog4-docker-builder-2:
     Docker Builder:
   motog5-perf:
   motog5-perf-2:


### PR DESCRIPTION
The current builder device group isn't owned by me or BC (by 'admin') so I'm hitting a permissions error when trying to start a build job. We didn't hit this issue when I switched to my API token because the other device groups were owned by BC. BC was granted permissions to access the device group by an "access group" (https://mozilla.testdroid.com/#admin/access-group/1), that I was never added to. We shouldn't see this again (when we switch to a role account) because the new device group isn't 'loaned' out via access group - or at least that's what I understand from talking with Sakari. 

Sakari also recommends not using 'admin' accounts (different from the 'admin' account) because they are able to see globally, but aren't able to access and modify those resources (the errors returned by the API are more confusing in this case).

This change allowed me to start a new build job.

before the change:

```
$ python mozilla_bitbar_devicepool/main.py run-test --update-bitbar --project-name mozilla-docker-build
...
Traceback (most recent call last):
  File "mozilla_bitbar_devicepool/main.py", line 174, in <module>
    main()
  File "mozilla_bitbar_devicepool/main.py", line 171, in main
    args.func(args)
  File "mozilla_bitbar_devicepool/main.py", line 76, in run_test
    run_test_for_project(args.project_name)
  File "/Users/aerickson/git/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 73, in run_test_for_project
    return run_test_with_configuration(test_configuration)
  File "/Users/aerickson/git/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 23, in run_test_with_configuration
    headers={'Content-type': 'application/json', 'Accept': 'application/json'})
  File "/Users/aerickson/git/mozilla-bitbar-devicepool/venv/lib/python3.7/site-packages/testdroid/__init__.py", line 274, in post
    raise RequestResponseError(res.text, res.status_code)
testdroid.RequestResponseError: Request Error: code 400: {"message":"Device group with id 45 is not available","statusCode":400}
```