### PR TITLE
Use 20200507T123744 in test

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200326T142021
+      DOCKER_IMAGE_VERSION: 20200507T123744
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200326T142021
+      DOCKER_IMAGE_VERSION: 20200507T123744
   # mozilla-gw-test-3:
   #   device_group_name: test-3
   #   framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -91,24 +91,24 @@ projects:
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
       DOCKER_IMAGE_VERSION: 20200326T142021
-  mozilla-gw-test-3:
-    device_group_name: test-3
-    framework_name: mozilla-usb
-    description: used for testing new images
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
-      # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200326T142021
-  mozilla-docker-image-test:
-    device_group_name: motog5-test
-    framework_name: mozilla-usb
-    description: Mozilla Docker image test
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
-      # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200326T142021
+  # mozilla-gw-test-3:
+  #   device_group_name: test-3
+  #   framework_name: mozilla-usb
+  #   description: used for testing new images
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
+  #     # replace with version to test
+  #     DOCKER_IMAGE_VERSION: 20200326T142021
+  # mozilla-docker-image-test:
+  #   device_group_name: motog5-test
+  #   framework_name: mozilla-usb
+  #   description: Mozilla Docker image test
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-g5
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-test-g5
+  #     # replace with version to test
+  #     DOCKER_IMAGE_VERSION: 20200326T142021
 # devices hooked up to battery hubs
 #   - pixel2-34, pixel2-35. motog5-08, motog5-15.
 device_groups:


### PR DESCRIPTION
Contains the changes in https://github.com/bclary/mozilla-bitbar-docker/pull/47 at 5b26759ea6982ee61cffeb0fc6ee263716189e1a.

from https://mozilla.testdroid.com/#testing/device-session/1994998/2007851/55381077

> 05-07 14:31:38.687 Successfully tagged mozilla-image:20200507T123744

Also disables empty test queues.