### PR TITLE
use 20200511T134445 in test

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200507T123744
+      DOCKER_IMAGE_VERSION: 20200511T134445
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200507T123744
+      DOCKER_IMAGE_VERSION: 20200511T134445
   # mozilla-gw-test-3:
   #   device_group_name: test-3
   #   framework_name: mozilla-usb


### PR DESCRIPTION
Contains changes from https://github.com/bclary/mozilla-bitbar-docker/pull/47 at 7e4fc8409e0bd4d0402a81f621f526f00b41cdfd.

https://mozilla.testdroid.com/#testing/device-session/1994998/2015901/55629286

> 05-11 13:56:44.316 Successfully tagged mozilla-image:20200511T134445
