### PR TITLE
use 20200511T134445 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20200326T142021
+      DOCKER_IMAGE_VERSION: 20200511T134445
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
Tarek is happy with the mercurial changes. 

Previously landed PR to use image in testing pools. https://github.com/bclary/mozilla-bitbar-devicepool/pull/121

Contains changes from bclary/mozilla-bitbar-docker#47 at 7e4fc8409e0bd4d0402a81f621f526f00b41cdfd.