### PR TITLE
exception parsing: use str vs e.message or e.text

### DIFF
--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -50,6 +50,9 @@ class ConfigurationException(Exception):
     def __init__(self, message):
         self.message = message
 
+    def __str__(self):
+        return self.message
+
 
 class ConfigurationFileException(ConfigurationException):
     pass
@@ -88,7 +91,7 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
     try:
         configuration_preflight()
     except ConfigurationFileException as e:
-        logger.error(e.message)
+        logger.error(str(e))
         logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
         sys.exit(1)
     configure_device_groups(update_bitbar=update_bitbar)

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -48,19 +48,18 @@ CONFIG = None
 
 class ConfigurationException(Exception):
     def __init__(self, message):
-        super(ConfigurationException, self).__init__(message)
         self.message = message
 
     def __str__(self):
         return self.message
 
+
 class ConfigurationFileException(ConfigurationException):
-    def __init__(self, message):
-        super(ConfigurationFileException, self).__init__(message)
+    pass
+
 
 class DuplicateProjectException(ConfigurationException):
-    def __init__(self, message):
-        super(DuplicateProjectException, self).__init__(message)
+    pass
 
 
 def get_filespath():

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -48,18 +48,19 @@ CONFIG = None
 
 class ConfigurationException(Exception):
     def __init__(self, message):
+        super(ConfigurationException, self).__init__(message)
         self.message = message
 
     def __str__(self):
         return self.message
 
-
 class ConfigurationFileException(ConfigurationException):
-    pass
-
+    def __init__(self, message):
+        super(ConfigurationFileException, self).__init__(message)
 
 class DuplicateProjectException(ConfigurationException):
-    pass
+    def __init__(self, message):
+        super(DuplicateProjectException, self).__init__(message)
 
 
 def get_filespath():

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -91,7 +91,7 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
     try:
         configuration_preflight()
     except ConfigurationFileException as e:
-        logger.error(str(e))
+        logger.error(e)
         logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
         sys.exit(1)
     configure_device_groups(update_bitbar=update_bitbar)

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -146,11 +146,11 @@ class TestRunManager(object):
                             logger.info('test run {} started'.format(
                                 test_run['id']))
                 except RequestResponseError as e:
-                    if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, e):
+                    if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, str(e)):
                         logger.error("Test files have been archived. Exiting so configuration is rerun...")
                         logger.error("%s: %s" % (e.__class__.__name__, e))
                         self.state = 'STOP'
-                    elif e.status_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, e):
+                    elif e.status_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, str(e)):
                         logger.error("Project does not exist!. Exiting so configuration is rerun...")
                         logger.error("%s: %s" % (e.__class__.__name__, e))
                         self.state = 'STOP'

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -146,20 +146,20 @@ class TestRunManager(object):
                             logger.info('test run {} started'.format(
                                 test_run['id']))
                 except RequestResponseError as e:
-                    if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, e.message):
+                    if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, str(e)):
                         logger.error("Test files have been archived. Exiting so configuration is rerun...")
-                        logger.error("%s: %s" % (e.__class__.__name__, e.message))
+                        logger.error("%s: %s" % (e.__class__.__name__, str(e)))
                         self.state = 'STOP'
-                    elif e.status_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, e.message):
+                    elif e.status_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, str(e)):
                         logger.error("Project does not exist!. Exiting so configuration is rerun...")
-                        logger.error("%s: %s" % (e.__class__.__name__, e.message))
+                        logger.error("%s: %s" % (e.__class__.__name__, str(e)))
                         self.state = 'STOP'
                     else:
-                        logger.error("%s: %s" % (e.__class__.__name__, e.message))
+                        logger.error("%s: %s" % (e.__class__.__name__, str(e)))
                 except Exception as e:
                     logger.error(
                         'Failed to create test run for group %s (%s: %s).'
-                        % (device_group_name, e.__class__.__name__, e.message),
+                        % (device_group_name, e.__class__.__name__, str(e)),
                         exc_info=True,
                         )
 

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -146,20 +146,20 @@ class TestRunManager(object):
                             logger.info('test run {} started'.format(
                                 test_run['id']))
                 except RequestResponseError as e:
-                    if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, str(e)):
+                    if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, e):
                         logger.error("Test files have been archived. Exiting so configuration is rerun...")
-                        logger.error("%s: %s" % (e.__class__.__name__, str(e)))
+                        logger.error("%s: %s" % (e.__class__.__name__, e))
                         self.state = 'STOP'
-                    elif e.status_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, str(e)):
+                    elif e.status_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, e):
                         logger.error("Project does not exist!. Exiting so configuration is rerun...")
-                        logger.error("%s: %s" % (e.__class__.__name__, str(e)))
+                        logger.error("%s: %s" % (e.__class__.__name__, e))
                         self.state = 'STOP'
                     else:
-                        logger.error("%s: %s" % (e.__class__.__name__, str(e)))
+                        logger.error("%s: %s" % (e.__class__.__name__, e))
                 except Exception as e:
                     logger.error(
                         'Failed to create test run for group %s (%s: %s).'
-                        % (device_group_name, e.__class__.__name__, str(e)),
+                        % (device_group_name, e.__class__.__name__, e),
                         exc_info=True,
                         )
 


### PR DESCRIPTION
fixes:

```
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]: Exception in thread mozilla-gw-unittest-p2:
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]: Traceback (most recent call last):
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 141, in handle_queue
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:     test_run = run_test_for_project(project_name)
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 73, in run_test_for_project
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:     return run_test_with_configuration(test_configuration)
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/runs.py", line 23, in run_test_with_configuration
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:     headers={'Content-type': 'application/json', 'Accept': 'application/json'})
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:   File "/home/bitbar/mozilla-bitbar-devicepool/venv/lib/python3.6/site-packages/testdroid/__init__.py", line 274, in post
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:     raise RequestResponseError(res.text, res.status_code)
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]: testdroid.RequestResponseError: Request Error: code 404: {"message":"FileEntity with id 4635199 does not exist","statusCode":404}
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]: During handling of the above exception, another exception occurred:
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]: Traceback (most recent call last):
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:   File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:     self.run()
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:   File "/usr/lib/python3.6/threading.py", line 864, in run
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:     self._target(*self._args, **self._kwargs)
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:   File "/home/bitbar/mozilla-bitbar-devicepool/mozilla_bitbar_devicepool/test_run_manager.py", line 149, in handle_queue
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]:     if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, e.message):
Jun 03 14:49:03 bitbar-devicepool-0 bash[22691]: AttributeError: 'RequestResponseError' object has no attribute 'message'
```