### PR TITLE
use 20200608T103501 in test

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200511T134445
+      DOCKER_IMAGE_VERSION: 20200608T103501
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200511T134445
+      DOCKER_IMAGE_VERSION: 20200608T103501
   # mozilla-gw-test-3:
   #   device_group_name: test-3
   #   framework_name: mozilla-usb


### PR DESCRIPTION
from https://mozilla.testdroid.com/#testing/device-session/2012095/2085036/57444571:

> 06-08 10:49:40.263 Successfully tagged mozilla-image:20200608T103501

built from https://github.com/bclary/mozilla-bitbar-docker/pull/48 @ 33ed50fb42381aff40985ed83059747848997011