### PR TITLE
use 20200608T103501 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20200511T134445
+      DOCKER_IMAGE_VERSION: 20200608T103501
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
Contains https://github.com/bclary/mozilla-bitbar-docker/pull/48.

Use in testing: https://github.com/bclary/mozilla-bitbar-devicepool/pull/124

tested in https://treeherder.mozilla.org/#/jobs?repo=try&revision=f76d7d883247cbc226e0dc223e9c9e2caaa1adf4