### PR TITLE
use 20200804T101109 in test

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -81,7 +81,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200608T103501
+      DOCKER_IMAGE_VERSION: 20200804T101109
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb
@@ -90,7 +90,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20200608T103501
+      DOCKER_IMAGE_VERSION: 20200804T101109
   # mozilla-gw-test-3:
   #   device_group_name: test-3
   #   framework_name: mozilla-usb


### PR DESCRIPTION
Built from https://github.com/bclary/mozilla-bitbar-docker/pull/49 at 0f7529337fbce6e5d4d5889365e8f7e3c0f7734e.

Build link: https://mozilla.testdroid.com/#testing/test-run/2131229/2212611
```08-04 10:52:24.438 Successfully tagged mozilla-image:20200804T101109```