### PR TITLE
use 20200804T101109 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20200608T103501
+      DOCKER_IMAGE_VERSION: 20200804T101109
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
Includes https://github.com/bclary/mozilla-bitbar-docker/pull/49.

Test results:
- g5: https://treeherder.mozilla.org/#/jobs?repo=try&revision=77dbe960c373a35a128570081f01a755765404aa
- p2: https://treeherder.mozilla.org/#/jobs?repo=try&revision=f6904b0f69ec4e8586e86c9ac40a3a161340ffae