### PR TITLE
run black and flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501, W503, E266, E402  ## TODO: fix up __init__.py and remove E402
+select = B,C,E,F,W,T4,B9

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ venv
 *~
 *.pyc
 *.egg-info
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
     rev: 19.10b0
     hooks:
     -   id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.2.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ install:
 
 # command to run tests
 script:
+  - pre-commit run --all-files
   - pyflakes mozilla_bitbar_devicepool/*.py
   - pytest -v mozilla_bitbar_devicepool

--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ pre-commit install  # install the pre-commit hook
 
 # Unit Testing
 
+You must install the development requirements first.  See the "Development" section above.
+
 ```
 pytest  # runs once
 # or

--- a/README.md
+++ b/README.md
@@ -290,3 +290,22 @@ To follow the log output of the bitbar service
 ```
 sudo journalctl _SYSTEMD_UNIT=bitbar.service --follow
 ```
+
+## Development
+
+```
+pip install -r requirements-dev.txt  # install deps
+pre-commit install  # install the pre-commit hook
+# make changes
+# commit
+# test
+# make a PR
+```
+
+# Unit Testing
+
+```
+pytest  # runs once
+# or
+pytest-watch  # monitors files for changes and reruns
+```

--- a/bin/device_group_report
+++ b/bin/device_group_report
@@ -2,14 +2,15 @@
 
 import argparse
 import sys
+
 try:
-  from mozilla_bitbar_devicepool.device_group_report import DeviceGroupReport
+    from mozilla_bitbar_devicepool.device_group_report import DeviceGroupReport
 except ImportError:
-  print("ERROR: Please install dependencies (`pip install -r requirements.txt`)!")
-  sys.exit(1)
+    print("ERROR: Please install dependencies (`pip install -r requirements.txt`)!")
+    sys.exit(1)
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-c', '--config-file', help='config file to inspect')
+parser.add_argument("-c", "--config-file", help="config file to inspect")
 args = parser.parse_args()
 
 dgr = DeviceGroupReport(config_path=args.config_file)

--- a/bin/stop_android_hardware_testing.sh
+++ b/bin/stop_android_hardware_testing.sh
@@ -4,5 +4,3 @@ pkill -USR2 -f main.py
 while pkill -0 -f main.py; do
     sleep 1
 done
-
-

--- a/config/config.yml
+++ b/config/config.yml
@@ -232,4 +232,3 @@ device_groups:
     pixel2-59:
   pixel2-batt:
   pixel2-batt-2:
-

--- a/mozilla_bitbar_devicepool/__init__.py
+++ b/mozilla_bitbar_devicepool/__init__.py
@@ -9,7 +9,7 @@
 import logging
 
 # TODO: put %(asctime)s back in?
-logging.basicConfig(format='%(threadName)26s %(levelname)-8s %(message)s')
+logging.basicConfig(format="%(threadName)26s %(levelname)-8s %(message)s")
 
 import copy
 import os
@@ -20,12 +20,13 @@ from testdroid import Testdroid
 modulepath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 logger = logging.getLogger()
 
-TESTDROID_URL=os.environ.get('TESTDROID_URL')
-TESTDROID_APIKEY=os.environ.get('TESTDROID_APIKEY')
+TESTDROID_URL = os.environ.get("TESTDROID_URL")
+TESTDROID_APIKEY = os.environ.get("TESTDROID_APIKEY")
 if TESTDROID_URL and TESTDROID_APIKEY:
     TESTDROID = Testdroid(apikey=TESTDROID_APIKEY, url=TESTDROID_URL)
 else:
     TESTDROID = None
+
 
 def lookup_key_value(dict_list, keyname):
     """Utility function to look up an object by key name from a list of
@@ -46,28 +47,31 @@ def lookup_key_value(dict_list, keyname):
 
 
 def get_filter(fields, **kwargs):
-    filter=[]
+    filter = []
     for fieldname in kwargs:
         fieldvalue = kwargs[fieldname]
         fieldtype = type(fieldvalue)
         if fieldtype != fields[fieldname]:
-            raise ValueError('filter field name {} type {} does not match {}'.format(
-                fieldname, fieldtype, fields[fieldname]))
-        fieldflag = ''
+            raise ValueError(
+                "filter field name {} type {} does not match {}".format(
+                    fieldname, fieldtype, fields[fieldname]
+                )
+            )
+        fieldflag = ""
         if fieldtype == int:
-            if 'time' in fieldname:
-                fieldflag = 'd'
+            if "time" in fieldname:
+                fieldflag = "d"
             else:
-                fieldflag = 'n'
+                fieldflag = "n"
         elif fieldtype == str:
-            fieldflag = 's'
+            fieldflag = "s"
         elif fieldtype == bool:
-            fieldflag = 'b'
+            fieldflag = "b"
         else:
-            raise ValueError('Unknown filter field type %s' % fieldtype)
-        filter.append('{}_{}_eq_{}'.format(
-            fieldflag, fieldname, fieldvalue))
+            raise ValueError("Unknown filter field type %s" % fieldtype)
+        filter.append("{}_{}_eq_{}".format(fieldflag, fieldname, fieldvalue))
     return filter
+
 
 def apply_dict_defaults(input_dict, defaults_dict):
     """Recursively sets the missing values in input_dict to those defined
@@ -84,7 +88,8 @@ def apply_dict_defaults(input_dict, defaults_dict):
         if isinstance(attribute, dict):
             # Recursively do nested dicts.
             new_dict[attribute_name] = apply_dict_defaults(
-                attribute, defaults_dict[attribute_name])
+                attribute, defaults_dict[attribute_name]
+            )
         else:
             new_dict[attribute_name] = attribute
 
@@ -92,6 +97,7 @@ def apply_dict_defaults(input_dict, defaults_dict):
 
 
 # download_file() cloned from autophone's urlretrieve()
+
 
 def download_file(url, dest, max_attempts=3):
     """Download file from url and save to dest.
@@ -103,10 +109,10 @@ def download_file(url, dest, max_attempts=3):
                    Defaults to 3.
     """
     parse_result = urllib.parse.urlparse(url)
-    if not parse_result.scheme or parse_result.scheme.startswith('file'):
+    if not parse_result.scheme or parse_result.scheme.startswith("file"):
         local_file = open(parse_result.path)
         with local_file:
-            with open(dest, 'wb') as dest_file:
+            with open(dest, "wb") as dest_file:
                 while True:
                     chunk = local_file.read(4096)
                     if not chunk:
@@ -119,7 +125,7 @@ def download_file(url, dest, max_attempts=3):
             r = requests.get(url, stream=True)
             if not r.ok:
                 r.raise_for_status()
-            with open(dest, 'wb') as dest_file:
+            with open(dest, "wb") as dest_file:
                 for chunk in r.iter_content(chunk_size=4096):
                     dest_file.write(chunk)
             break
@@ -127,9 +133,17 @@ def download_file(url, dest, max_attempts=3):
             logger.info("download_file(%s, %s) %s", url, dest, http_error)
             raise
         except (requests.ConnectionError, requests.Timeout) as e:
-            logger.warning("utils.download_file: %s: Attempt %s: %s",
-                           url, attempt, e)
+            logger.warning("utils.download_file: %s: Attempt %s: %s", url, attempt, e)
             if attempt == max_attempts - 1:
                 raise
 
-__all__ = ["configuration", "device_groups", "devices", "files", "frameworks", "projects", "runs"]
+
+__all__ = [
+    "configuration",
+    "device_groups",
+    "devices",
+    "files",
+    "frameworks",
+    "projects",
+    "runs",
+]

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -9,11 +9,7 @@ import sys
 
 import yaml
 
-from mozilla_bitbar_devicepool import (
-    TESTDROID,
-    apply_dict_defaults,
-    logger
-)
+from mozilla_bitbar_devicepool import TESTDROID, apply_dict_defaults, logger
 
 from mozilla_bitbar_devicepool.devices import get_devices
 from mozilla_bitbar_devicepool.files import get_files
@@ -34,12 +30,12 @@ from mozilla_bitbar_devicepool.projects import (
 )
 
 BITBAR_CACHE = {
-    'device_groups': {},
-    'devices': {},
-    'files': {},
-    'frameworks': {},
-    'projects': {},
-    'test_runs': {},
+    "device_groups": {},
+    "devices": {},
+    "files": {},
+    "frameworks": {},
+    "projects": {},
+    "test_runs": {},
 }
 
 FILESPATH = None
@@ -57,8 +53,10 @@ class ConfigurationException(Exception):
 class ConfigurationFileException(ConfigurationException):
     pass
 
+
 class ConfigurationFileDuplicateFilenamesException(ConfigurationFileException):
     pass
+
 
 class DuplicateProjectException(ConfigurationException):
     pass
@@ -69,21 +67,27 @@ def get_filespath():
     """
     return FILESPATH
 
+
 def ensure_filenames_are_unique(config):
     seen_filenames = []
     # TODO: break extraction of filenames out for easier testing
     try:
-        for item in config['projects']:
-            for deeper_item in config['projects'][item]:
+        for item in config["projects"]:
+            for deeper_item in config["projects"][item]:
                 if deeper_item == "application_file" or deeper_item == "test_file":
-                    a_filename = config['projects'][item][deeper_item]
+                    a_filename = config["projects"][item][deeper_item]
                     if a_filename in seen_filenames:
-                        raise ConfigurationFileDuplicateFilenamesException("duplicate filenames found!")
+                        raise ConfigurationFileDuplicateFilenamesException(
+                            "duplicate filenames found!"
+                        )
                     seen_filenames.append(a_filename)
     except KeyError as e:
         print(e)
-        raise ConfigurationFileException("config does not appear to be in proper format")
+        raise ConfigurationFileException(
+            "config does not appear to be in proper format"
+        )
     return seen_filenames
+
 
 def configure(bitbar_configpath, filespath=None, update_bitbar=False):
     """Parse and load the configuration yaml file
@@ -97,14 +101,14 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
     """
     global CONFIG, FILESPATH
 
-    FILESPATH=filespath
+    FILESPATH = filespath
 
-    logger.info('configure: starting configuration')
+    logger.info("configure: starting configuration")
     start = time.time()
 
     with open(bitbar_configpath) as bitbar_configfile:
         CONFIG = yaml.load(bitbar_configfile.read(), Loader=yaml.SafeLoader)
-    logger.info('configure: performing checks')
+    logger.info("configure: performing checks")
     try:
         ensure_filenames_are_unique(CONFIG)
     except (ConfigurationFileException) as e:
@@ -115,49 +119,55 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
         configuration_preflight()
     except ConfigurationFileException as e:
         logger.error(e)
-        logger.error("Configuration files seem to be missing! Please place and restart. Exiting...")
+        logger.error(
+            "Configuration files seem to be missing! Please place and restart. Exiting..."
+        )
         sys.exit(1)
     configure_device_groups(update_bitbar=update_bitbar)
     configure_projects(update_bitbar=update_bitbar)
 
     end = time.time()
     diff = end - start
-    logger.info('configure: configuration took {} seconds'.format(diff))
+    logger.info("configure: configuration took {} seconds".format(diff))
+
 
 def expand_configuration():
     """Materializes the configuration. Sets default values when none are specified.
     """
-    projects_config = CONFIG['projects']
-    project_defaults = projects_config['defaults']
+    projects_config = CONFIG["projects"]
+    project_defaults = projects_config["defaults"]
 
     for project_name in projects_config:
-        if project_name == 'defaults':
+        if project_name == "defaults":
             continue
 
         project_config = projects_config[project_name]
         # Set the default project values.
-        projects_config[project_name] = apply_dict_defaults(project_config, project_defaults)
+        projects_config[project_name] = apply_dict_defaults(
+            project_config, project_defaults
+        )
 
     # TODO: remove 'defaults' from CONFIG['projects']?
     #   - would save later code from having to exclude it
 
+
 def configuration_preflight():
     """Ensure that everything necessary for configuration is present.
     """
-    projects_config = CONFIG['projects']
+    projects_config = CONFIG["projects"]
 
     for project_name in projects_config:
-        if project_name == 'defaults':
+        if project_name == "defaults":
             continue
 
         project_config = projects_config[project_name]
-        file_name =  project_config.get('test_file')
+        file_name = project_config.get("test_file")
         if file_name:
             file_path = os.path.join(FILESPATH, file_name)
             if not os.path.exists(file_path):
                 raise ConfigurationFileException("'%s' does not exist!" % file_path)
 
-        file_name = project_config.get('application_file')
+        file_name = project_config.get("application_file")
         if file_name:
             file_path = os.path.join(FILESPATH, file_name)
             if not os.path.exists(file_path):
@@ -173,13 +183,15 @@ def configure_device_groups(update_bitbar=False):
                    objects for each contained device.
     """
     # Cache the bitbar device data in the configuration.
-    devices_cache = BITBAR_CACHE['devices'] = {}
+    devices_cache = BITBAR_CACHE["devices"] = {}
     for device in get_devices():
-        devices_cache[device['displayName']] = device
+        devices_cache[device["displayName"]] = device
 
-    device_groups_config = CONFIG['device_groups']
+    device_groups_config = CONFIG["device_groups"]
     for device_group_name in device_groups_config:
-        logger.info('configure_device_groups: configuring group {}'.format(device_group_name))
+        logger.info(
+            "configure_device_groups: configuring group {}".format(device_group_name)
+        )
         device_group_config = device_groups_config[device_group_name]
         if device_group_config is None:
             # Handle the case where the configured device group is empty.
@@ -189,7 +201,11 @@ def configure_device_groups(update_bitbar=False):
         # get the current definition of the device group at bitbar.
         bitbar_device_groups = get_device_groups(displayname=device_group_name)
         if len(bitbar_device_groups) > 1:
-            raise Exception('device group {} has {} duplicates'.format(device_group_name, len(bitbar_device_groups) - 1))
+            raise Exception(
+                "device group {} has {} duplicates".format(
+                    device_group_name, len(bitbar_device_groups) - 1
+                )
+            )
         elif len(bitbar_device_groups) == 1:
             bitbar_device_group = bitbar_device_groups[0]
         else:
@@ -197,35 +213,60 @@ def configure_device_groups(update_bitbar=False):
             if update_bitbar:
                 bitbar_device_group = create_device_group(device_group_name)
             else:
-                raise Exception('device group {} does not exist but can not create.'.format(device_group_name))
+                raise Exception(
+                    "device group {} does not exist but can not create.".format(
+                        device_group_name
+                    )
+                )
 
-        bitbar_device_group_devices = get_device_group_devices(bitbar_device_group['id'])
-        bitbar_device_group_names = set([device['displayName'] for device in bitbar_device_group_devices])
+        bitbar_device_group_devices = get_device_group_devices(
+            bitbar_device_group["id"]
+        )
+        bitbar_device_group_names = set(
+            [device["displayName"] for device in bitbar_device_group_devices]
+        )
 
         # determine which devices need to be deleted from or added to
         # the device group at bitbar.
         delete_device_names = bitbar_device_group_names - new_device_group_names
         add_device_names = new_device_group_names - bitbar_device_group_names
 
-        delete_device_ids = [ devices_cache[name]['id'] for name in delete_device_names ]
-        add_device_ids = [ devices_cache[name]['id'] for name in add_device_names if name in devices_cache ]
+        delete_device_ids = [devices_cache[name]["id"] for name in delete_device_names]
+        add_device_ids = [
+            devices_cache[name]["id"]
+            for name in add_device_names
+            if name in devices_cache
+        ]
 
         for device_id in delete_device_ids:
             if update_bitbar:
-                delete_device_from_device_group(bitbar_device_group['id'], device_id)
+                delete_device_from_device_group(bitbar_device_group["id"], device_id)
             else:
-                raise Exception('Attempting to remove device {} from group {}, but not configured to update bitbar config.'.format(device_id, bitbar_device_group['id']))
-            bitbar_device_group['deviceCount'] -= 1
-            if bitbar_device_group['deviceCount'] < 0:
-                raise Exception('device group {} has negative deviceCount'.format(device_group_name))
+                raise Exception(
+                    "Attempting to remove device {} from group {}, but not configured to update bitbar config.".format(
+                        device_id, bitbar_device_group["id"]
+                    )
+                )
+            bitbar_device_group["deviceCount"] -= 1
+            if bitbar_device_group["deviceCount"] < 0:
+                raise Exception(
+                    "device group {} has negative deviceCount".format(device_group_name)
+                )
 
         if add_device_ids:
             if update_bitbar:
-                bitbar_device_group = add_devices_to_device_group(bitbar_device_group['id'], add_device_ids)
+                bitbar_device_group = add_devices_to_device_group(
+                    bitbar_device_group["id"], add_device_ids
+                )
             else:
-                raise Exception('Attempting to add device(s) {} to group {}, but not configured to update bitbar config.'.format(add_device_ids, bitbar_device_group['id']))
+                raise Exception(
+                    "Attempting to add device(s) {} to group {}, but not configured to update bitbar config.".format(
+                        add_device_ids, bitbar_device_group["id"]
+                    )
+                )
 
-        BITBAR_CACHE['device_groups'][device_group_name] = bitbar_device_group
+        BITBAR_CACHE["device_groups"][device_group_name] = bitbar_device_group
+
 
 def configure_projects(update_bitbar=False):
     """Configure projects from configuration.
@@ -238,36 +279,50 @@ def configure_projects(update_bitbar=False):
     on the other projects if they are not already explicitly set.
 
     """
-    projects_config = CONFIG['projects']
+    projects_config = CONFIG["projects"]
 
     project_total = len(projects_config)
     counter = 0
     for project_name in projects_config:
         counter += 1
-        log_header = "configure_projects: {} ({}/{})".format(project_name, counter, project_total)
+        log_header = "configure_projects: {} ({}/{})".format(
+            project_name, counter, project_total
+        )
 
-        if project_name == 'defaults':
-            logger.info('{}: skipping'.format(log_header))
+        if project_name == "defaults":
+            logger.info("{}: skipping".format(log_header))
             continue
-        logger.info('{}: configuring...'.format(log_header))
+        logger.info("{}: configuring...".format(log_header))
 
         project_config = projects_config[project_name]
         bitbar_projects = get_projects(name=project_name)
         if len(bitbar_projects) > 1:
-            raise DuplicateProjectException('project {} has {} duplicates'.format(project_name, len(bitbar_projects) - 1))
+            raise DuplicateProjectException(
+                "project {} has {} duplicates".format(
+                    project_name, len(bitbar_projects) - 1
+                )
+            )
         elif len(bitbar_projects) == 1:
             bitbar_project = bitbar_projects[0]
         else:
             if update_bitbar:
-                bitbar_project = create_project(project_name, project_type=project_config['project_type'])
+                bitbar_project = create_project(
+                    project_name, project_type=project_config["project_type"]
+                )
             else:
-                raise Exception('Project {} does not exist, but not creating as not configured to update bitbar!'.format(project_name))
+                raise Exception(
+                    "Project {} does not exist, but not creating as not configured to update bitbar!".format(
+                        project_name
+                    )
+                )
 
-        framework_name = project_config['framework_name']
-        BITBAR_CACHE['frameworks'][framework_name] = get_frameworks(name=framework_name)[0]
+        framework_name = project_config["framework_name"]
+        BITBAR_CACHE["frameworks"][framework_name] = get_frameworks(
+            name=framework_name
+        )[0]
 
-        logger.info('{}: configuring test file'.format(log_header))
-        file_name =  project_config.get('test_file')
+        logger.info("{}: configuring test file".format(log_header))
+        file_name = project_config.get("test_file")
         if file_name:
             bitbar_files = get_files(name=file_name)
             if len(bitbar_files) > 0:
@@ -277,11 +332,15 @@ def configure_projects(update_bitbar=False):
                     TESTDROID.upload_file(os.path.join(FILESPATH, file_name))
                     bitbar_file = get_files(name=file_name)[-1]
                 else:
-                    raise Exception('Test file {} not found and not configured to update bitbar configuration!'.format(file_name))
-            BITBAR_CACHE['files'][file_name] = bitbar_file
+                    raise Exception(
+                        "Test file {} not found and not configured to update bitbar configuration!".format(
+                            file_name
+                        )
+                    )
+            BITBAR_CACHE["files"][file_name] = bitbar_file
 
-        logger.info('{}: configuring application file'.format(log_header))
-        file_name = project_config.get('application_file')
+        logger.info("{}: configuring application file".format(log_header))
+        file_name = project_config.get("application_file")
         if file_name:
             bitbar_files = get_files(name=file_name)
             if len(bitbar_files) > 0:
@@ -291,49 +350,79 @@ def configure_projects(update_bitbar=False):
                     TESTDROID.upload_file(os.path.join(FILESPATH, file_name))
                     bitbar_file = get_files(name=file_name)[-1]
                 else:
-                    raise Exception('Application file {} not found and not configured to update bitbar configuration!'.format(file_name))
-            BITBAR_CACHE['files'][file_name] = bitbar_file
+                    raise Exception(
+                        "Application file {} not found and not configured to update bitbar configuration!".format(
+                            file_name
+                        )
+                    )
+            BITBAR_CACHE["files"][file_name] = bitbar_file
 
         # Sync the base project properties if they have changed.
-        if (project_config['archivingStrategy'] != bitbar_project['archivingStrategy'] or
-            project_config['archivingItemCount'] != bitbar_project['archivingItemCount'] or
-            project_config['description'] != bitbar_project['description']):
+        if (
+            project_config["archivingStrategy"] != bitbar_project["archivingStrategy"]
+            or project_config["archivingItemCount"]
+            != bitbar_project["archivingItemCount"]
+            or project_config["description"] != bitbar_project["description"]
+        ):
             # project basic attributes changed in config, update bitbar version.
             if update_bitbar:
                 bitbar_project = update_project(
-                    bitbar_project['id'],
+                    bitbar_project["id"],
                     project_name,
-                    archiving_item_count=project_config['archivingItemCount'],
-                    archiving_strategy=project_config['archivingStrategy'],
-                    description=project_config['description'])
+                    archiving_item_count=project_config["archivingItemCount"],
+                    archiving_strategy=project_config["archivingStrategy"],
+                    description=project_config["description"],
+                )
             else:
-                logger.error('archivingStrategy: pc: "{}" bb: "{}"'.format(project_config['archivingStrategy'], bitbar_project['archivingStrategy']))
-                logger.error('archivingItemCount: pc: "{}" bb: "{}"'.format(project_config['archivingItemCount'], bitbar_project['archivingItemCount']))
-                logger.error('description: pc: "{}" bb: "{}"'.format(project_config['description'], bitbar_project['description']))
-                raise Exception('The remote configuration for {} differs from the local configuration, but not configured to update bitbar!'.format(project_name))
+                logger.error(
+                    'archivingStrategy: pc: "{}" bb: "{}"'.format(
+                        project_config["archivingStrategy"],
+                        bitbar_project["archivingStrategy"],
+                    )
+                )
+                logger.error(
+                    'archivingItemCount: pc: "{}" bb: "{}"'.format(
+                        project_config["archivingItemCount"],
+                        bitbar_project["archivingItemCount"],
+                    )
+                )
+                logger.error(
+                    'description: pc: "{}" bb: "{}"'.format(
+                        project_config["description"], bitbar_project["description"]
+                    )
+                )
+                raise Exception(
+                    "The remote configuration for {} differs from the local configuration, but not configured to update bitbar!".format(
+                        project_name
+                    )
+                )
 
-        additional_parameters = project_config['additional_parameters']
-        if 'TC_WORKER_TYPE' in additional_parameters:
+        additional_parameters = project_config["additional_parameters"]
+        if "TC_WORKER_TYPE" in additional_parameters:
             # Add the TASKCLUSTER_ACCESS_TOKEN from the environment to
             # the additional_parameters in order that the bitbar
             # projects may be configured to use it. Non-taskcluster
             # projects such as mozilla-docker-build are not invoke by
             # Taskcluster currently.
-            taskcluster_access_token_name = additional_parameters['TC_WORKER_TYPE'].replace('-', '_')
-            additional_parameters['TASKCLUSTER_ACCESS_TOKEN'] = os.environ[taskcluster_access_token_name]
+            taskcluster_access_token_name = additional_parameters[
+                "TC_WORKER_TYPE"
+            ].replace("-", "_")
+            additional_parameters["TASKCLUSTER_ACCESS_TOKEN"] = os.environ[
+                taskcluster_access_token_name
+            ]
 
-        BITBAR_CACHE['projects'][project_name] = bitbar_project
-        BITBAR_CACHE['projects'][project_name]['lock'] = threading.Lock()
+        BITBAR_CACHE["projects"][project_name] = bitbar_project
+        BITBAR_CACHE["projects"][project_name]["lock"] = threading.Lock()
 
-        device_group_name = project_config['device_group_name']
-        device_group = BITBAR_CACHE['device_groups'][device_group_name]
+        device_group_name = project_config["device_group_name"]
+        device_group = BITBAR_CACHE["device_groups"][device_group_name]
 
-        BITBAR_CACHE['projects'][project_name]['stats'] = {
-            'COUNT': device_group['deviceCount'],
-            'IDLE': 0,
-            'OFFLINE_DEVICES': 0,
-            'OFFLINE': 0,
-            'DISABLED': 0,
-            'RUNNING': 0,
-            'WAITING': 0,
+        BITBAR_CACHE["projects"][project_name]["stats"] = {
+            "COUNT": device_group["deviceCount"],
+            "IDLE": 0,
+            "OFFLINE_DEVICES": 0,
+            "OFFLINE": 0,
+            "DISABLED": 0,
+            "RUNNING": 0,
+            "WAITING": 0,
         }

--- a/mozilla_bitbar_devicepool/configuration_test.py
+++ b/mozilla_bitbar_devicepool/configuration_test.py
@@ -7,7 +7,7 @@ from mozilla_bitbar_devicepool import configuration
 import pytest
 import yaml
 
-test_configuration_1 = '''
+test_configuration_1 = """
 projects:
   defaults:
     application_file: aerickson-Testdroid.apk
@@ -31,9 +31,9 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/blah2
       TC_WORKER_TYPE: blah2
- '''
+ """
 
-test_configuration_2 = '''
+test_configuration_2 = """
 projects:
   defaults:
     application_file: aerickson-Testdroid.apk
@@ -57,25 +57,29 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/blah2
       TC_WORKER_TYPE: blah2
- '''
+ """
+
 
 def test_unique_filenames_extraction():
-  config = yaml.load(test_configuration_1, Loader=yaml.SafeLoader)
-  assert (sorted(configuration.ensure_filenames_are_unique(config)) ==
-          sorted(['aerickson-empty-test2.zip',
-                  'aerickson-Testdroid.apk',
-                  'aerickson-empty-test.zip']
-          )
-  )
+    config = yaml.load(test_configuration_1, Loader=yaml.SafeLoader)
+    assert sorted(configuration.ensure_filenames_are_unique(config)) == sorted(
+        [
+            "aerickson-empty-test2.zip",
+            "aerickson-Testdroid.apk",
+            "aerickson-empty-test.zip",
+        ]
+    )
+
 
 def test_unique_filenames_ok_config():
-  config = yaml.load(test_configuration_1, Loader=yaml.SafeLoader)
-  try:
-    configuration.ensure_filenames_are_unique(config)
-  except Exception:
-    pytest.fail("shouldn't be any exceptions")
+    config = yaml.load(test_configuration_1, Loader=yaml.SafeLoader)
+    try:
+        configuration.ensure_filenames_are_unique(config)
+    except Exception:
+        pytest.fail("shouldn't be any exceptions")
+
 
 def test_unique_filenames_bad_config():
-  config = yaml.load(test_configuration_2, Loader=yaml.SafeLoader)
-  with pytest.raises(configuration.ConfigurationFileDuplicateFilenamesException):
-    configuration.ensure_filenames_are_unique(config)
+    config = yaml.load(test_configuration_2, Loader=yaml.SafeLoader)
+    with pytest.raises(configuration.ConfigurationFileDuplicateFilenamesException):
+        configuration.ensure_filenames_are_unique(config)

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -49,10 +49,10 @@ class DeviceGroupReport:
             # print(the_item)
             if the_item:
                 for device in the_item:
-                    if 'pixel2' in device:
-                        self.device_dict['p2'] = self.device_dict.get('p2', 0) + 1
-                    if 'motog5' in device:
-                        self.device_dict['g5'] = self.device_dict.get('g5', 0) + 1
+                    if "pixel2" in device:
+                        self.device_dict["p2"] = self.device_dict.get("p2", 0) + 1
+                    if "motog5" in device:
+                        self.device_dict["g5"] = self.device_dict.get("g5", 0) + 1
 
     def main(self):
         self.get_report_dict()

--- a/mozilla_bitbar_devicepool/device_groups.py
+++ b/mozilla_bitbar_devicepool/device_groups.py
@@ -25,16 +25,13 @@ def get_device_groups(**kwargs):
        get_device_groups() # Return all device groups
        get_device_groups(displayname='pixel2-perf') # Return pixel2-perf device group.
     """
-    fields = {
-        'displayname': str,
-        'id': int,
-        'ostype': str
-        }
+    fields = {"displayname": str, "id": int, "ostype": str}
 
     filter = get_filter(fields, **kwargs)
-    response = TESTDROID.get('/api/v2/me/device-groups',
-                             payload={'limit': 0, 'filter': filter})
-    return response['data']
+    response = TESTDROID.get(
+        "/api/v2/me/device-groups", payload={"limit": 0, "filter": filter}
+    )
+    return response["data"]
 
 
 def get_device_group(id):
@@ -45,9 +42,10 @@ def get_device_group(id):
     Examples:
        get_device_group(27) # Return device group with id 27
     """
-    response = TESTDROID.get('/api/v2/device-groups/{}'.format(id),
-                             payload={'limit': 0, 'filter': filter})
-    return response['data']
+    response = TESTDROID.get(
+        "/api/v2/device-groups/{}".format(id), payload={"limit": 0, "filter": filter}
+    )
+    return response["data"]
 
 
 def get_device_group_devices(id, **kwargs):
@@ -73,21 +71,23 @@ def get_device_group_devices(id, **kwargs):
        get_device_group_devices(27, displayname='pixel2-27') # Return devices for device group with id 27 and displayname pixel2-27.
     """
     fields = {
-        'displayname': str,
-        'enabled': bool,
-        'id': int,
-        'locked': bool,
-        'online': bool,
-        'ostype': str
-        }
+        "displayname": str,
+        "enabled": bool,
+        "id": int,
+        "locked": bool,
+        "online": bool,
+        "ostype": str,
+    }
 
     filter = get_filter(fields, **kwargs)
-    response = TESTDROID.get('/api/v2/device-groups/{}/devices'.format(id),
-                             payload={'limit': 0, 'filter': filter})
-    return response['data']
+    response = TESTDROID.get(
+        "/api/v2/device-groups/{}/devices".format(id),
+        payload={"limit": 0, "filter": filter},
+    )
+    return response["data"]
 
 
-def create_device_group(displayname, ostype='ANDROID'):
+def create_device_group(displayname, ostype="ANDROID"):
     """Create a device group for the current user.
 
     :param displayname: display name for the device group.
@@ -100,12 +100,13 @@ def create_device_group(displayname, ostype='ANDROID'):
     """
     me = TESTDROID.get_me()
     payload = {
-        'displayName': displayname,
-        'osType': ostype,
+        "displayName": displayname,
+        "osType": ostype,
     }
 
-    response = TESTDROID.post(path='/users/{}/device-groups'.format(me['id']),
-                             payload=payload)
+    response = TESTDROID.post(
+        path="/users/{}/device-groups".format(me["id"]), payload=payload
+    )
     return response
 
 
@@ -119,11 +120,12 @@ def add_devices_to_device_group(id, deviceids):
        add_device_to_device_group(40, [31])')
     """
     payload = {
-        'deviceIds[]': deviceids,
+        "deviceIds[]": deviceids,
     }
 
-    response = TESTDROID.post(path='/device-groups/{}/devices'.format(id),
-                             payload=payload)
+    response = TESTDROID.post(
+        path="/device-groups/{}/devices".format(id), payload=payload
+    )
     return response
 
 
@@ -136,7 +138,7 @@ def delete_device_from_device_group(id, deviceid):
     Examples:
        delete_device_group(99, 31)
     """
-    TESTDROID.delete(path='/device-groups/{}/devices/{}'.format(id, deviceid))
+    TESTDROID.delete(path="/device-groups/{}/devices/{}".format(id, deviceid))
 
 
 def delete_device_group(id):
@@ -148,4 +150,4 @@ def delete_device_group(id):
        delete_device_group(99)
     """
 
-    TESTDROID.delete(path='/device-groups/{}'.format(id))
+    TESTDROID.delete(path="/device-groups/{}".format(id))

--- a/mozilla_bitbar_devicepool/devices.py
+++ b/mozilla_bitbar_devicepool/devices.py
@@ -30,18 +30,17 @@ def get_devices(**kwargs):
        get_devices(displayname='pixel2-25') # Return pixel2-25
     """
     fields = {
-        'displayname': str,
-        'enabled': bool,
-        'id': int,
-        'locked': bool,
-        'online': bool,
-        'ostype': str
-        }
+        "displayname": str,
+        "enabled": bool,
+        "id": int,
+        "locked": bool,
+        "online": bool,
+        "ostype": str,
+    }
 
     filter = get_filter(fields, **kwargs)
-    response = TESTDROID.get('/api/v2/devices',
-                             payload={'limit': 0, 'filter': filter})
-    return response['data']
+    response = TESTDROID.get("/api/v2/devices", payload={"limit": 0, "filter": filter})
+    return response["data"]
 
 
 def get_device(id):
@@ -52,9 +51,11 @@ def get_device(id):
     Examples:
        get_device(1) # Return device with id 1
     """
-    response = TESTDROID.get('/api/v2/devices/{}'.format(id),
-                             payload={'limit': 0, 'filter': filter})
+    response = TESTDROID.get(
+        "/api/v2/devices/{}".format(id), payload={"limit": 0, "filter": filter}
+    )
     return response
+
 
 def get_device_problems(device_model=None):
     """Return list of matching Bitbar devices with device problems.
@@ -62,23 +63,22 @@ def get_device_problems(device_model=None):
     :param device_model: string prefix of device names to match.
     """
 
-    path = 'admin/device-problems'
-    payload={'limit': 0}
-    data = TESTDROID.get(path=path, payload=payload)['data']
+    path = "admin/device-problems"
+    payload = {"limit": 0}
+    data = TESTDROID.get(path=path, payload=payload)["data"]
     if device_model:
-        data = [d for d in data
-                if d['deviceName'].startswith(device_model)]
+        data = [d for d in data if d["deviceName"].startswith(device_model)]
     else:
-        data = [d for d in data
-                if d['deviceName'] != "Docker Builder"]
+        data = [d for d in data if d["deviceName"] != "Docker Builder"]
     return data
+
 
 def get_offline_devices(device_model=None):
     device_problems = get_device_problems(device_model=device_model)
     offline_devices = []
     for device_problem in device_problems:
-        problems = device_problem['problems']
+        problems = device_problem["problems"]
         for problem in problems:
-            if problem['type'] == 'OFFLINE':
-                offline_devices.append(device_problem['deviceModelName'])
+            if problem["type"] == "OFFLINE":
+                offline_devices.append(device_problem["deviceModelName"])
     return offline_devices

--- a/mozilla_bitbar_devicepool/files.py
+++ b/mozilla_bitbar_devicepool/files.py
@@ -23,18 +23,17 @@ def get_files(**kwargs):
     https://mozilla.testdroid.com/cloud/swagger-ui.html#/File/getFilesUsingGET
     """
     fields = {
-        'createtime': int,
-        'direction': str,
-        'id': int,
-        'mimetype': str,
-        'name': str,
-        'size': int,
-        'state': str,
+        "createtime": int,
+        "direction": str,
+        "id": int,
+        "mimetype": str,
+        "name": str,
+        "size": int,
+        "state": str,
     }
 
     filter = get_filter(fields, **kwargs)
-    response = TESTDROID.get('/api/v2/files',
-                             payload={'limit': 0,
-                                      'filter': filter,
-                                      'sort': 'createTime_a'})
-    return response['data']
+    response = TESTDROID.get(
+        "/api/v2/files", payload={"limit": 0, "filter": filter, "sort": "createTime_a"}
+    )
+    return response["data"]

--- a/mozilla_bitbar_devicepool/frameworks.py
+++ b/mozilla_bitbar_devicepool/frameworks.py
@@ -29,15 +29,16 @@ def get_frameworks(**kwargs):
        get_devices(displayname='pixel2-25') # Return pixel2-25
     """
     fields = {
-        'id': int,
-        'jobconfigid': int,
-        'labelname': str,
-        'name': str,
-        'ostype': str,
-        'type': str,
-        }
+        "id": int,
+        "jobconfigid": int,
+        "labelname": str,
+        "name": str,
+        "ostype": str,
+        "type": str,
+    }
 
     filter = get_filter(fields, **kwargs)
-    response = TESTDROID.get('/api/v2/admin/frameworks',
-                             payload={'limit': 0, 'filter': filter})
-    return response['data']
+    response = TESTDROID.get(
+        "/api/v2/admin/frameworks", payload={"limit": 0, "filter": filter}
+    )
+    return response["data"]

--- a/mozilla_bitbar_devicepool/main.py
+++ b/mozilla_bitbar_devicepool/main.py
@@ -19,7 +19,10 @@ from mozilla_bitbar_devicepool.runs import run_test_for_project
 from mozilla_bitbar_devicepool.test_run_manager import TestRunManager
 
 
-testdroid_apk_url = "https://github.com/bitbar/bitbar-samples/blob/master/apps/builds/Testdroid.apk"
+testdroid_apk_url = (
+    "https://github.com/bitbar/bitbar-samples/blob/master/apps/builds/Testdroid.apk"
+)
+
 
 def download_testdroid_apk(args):
     if args.filename:
@@ -27,10 +30,10 @@ def download_testdroid_apk(args):
     else:
         testdroid_apk = os.path.join(args.files, os.path.basename(testdroid_apk_url))
     if os.path.exists(testdroid_apk) and not args.force:
-        logger.warning('%s exists. Skipping download.' % testdroid_apk)
+        logger.warning("%s exists. Skipping download." % testdroid_apk)
     else:
         # Add ?raw=true to force download.
-        download_file(testdroid_apk_url+'?raw=true', testdroid_apk)
+        download_file(testdroid_apk_url + "?raw=true", testdroid_apk)
 
 
 def empty_test_zip(args):
@@ -42,18 +45,24 @@ def empty_test_zip(args):
 
 def test_run_manager(args):
     if not TESTDROID:
-        logger.error("The environment variabels TESTDROID_URL, TESTDROID_APIKEY both need to be set.")
+        logger.error(
+            "The environment variabels TESTDROID_URL, TESTDROID_APIKEY both need to be set."
+        )
         sys.exit(1)
 
     if args.bitbar_config is None:
-        bitbar_configpath = os.path.join(modulepath, 'config', 'config.yml')
+        bitbar_configpath = os.path.join(modulepath, "config", "config.yml")
     else:
         bitbar_configpath = args.bitbar_config
 
     try:
-        configuration.configure(bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar)
+        configuration.configure(
+            bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar
+        )
     except configuration.DuplicateProjectException as e:
-        logger.error("Duplicate project found! Please archive all but one and restart. Exiting...")
+        logger.error(
+            "Duplicate project found! Please archive all but one and restart. Exiting..."
+        )
         logger.error(e)
         sys.exit(1)
 
@@ -63,18 +72,23 @@ def test_run_manager(args):
 
 def run_test(args):
     if not TESTDROID:
-        logger.error("The environment variabels TESTDROID_URL, TESTDROID_APIKEY both need to be set.")
+        logger.error(
+            "The environment variabels TESTDROID_URL, TESTDROID_APIKEY both need to be set."
+        )
         sys.exit(1)
 
     if args.bitbar_config is None:
-        bitbar_configpath = os.path.join(modulepath, 'config', 'config.yml')
+        bitbar_configpath = os.path.join(modulepath, "config", "config.yml")
     else:
         bitbar_configpath = args.bitbar_config
 
-    configuration.configure(bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar)
+    configuration.configure(
+        bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar
+    )
 
     run_test_for_project(args.project_name)
     logger.info("run started for project '%s'" % args.project_name)
+
 
 def main():
 
@@ -105,63 +119,93 @@ Terminate Now
 
     Abort any running test containers and exit immediately.
 
-"""
-)
-    parser.add_argument("--files",
-                        default=os.path.join(modulepath, "files"),
-                        help="Directory where downloaded files are saved. "
-                        "Defaults to %s/files" % modulepath)
-    parser.add_argument('--log-level', dest='log_level',
-                        choices=['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'],
-                        default='INFO',
-                        help='Logging level. Defaults to INFO.')
+""",
+    )
+    parser.add_argument(
+        "--files",
+        default=os.path.join(modulepath, "files"),
+        help="Directory where downloaded files are saved. "
+        "Defaults to %s/files" % modulepath,
+    )
+    parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        default="INFO",
+        help="Logging level. Defaults to INFO.",
+    )
 
-    subparsers = parser.add_subparsers(help="Specify one of the positional arguments to select the command to execute.")
+    subparsers = parser.add_subparsers(
+        help="Specify one of the positional arguments to select the command to execute."
+    )
 
     ### download-test-apk ###
-    subparser = subparsers.add_parser("download-testdroid-apk",
-                                      help="Download Testdroid.apk from %s to files/ then exit." % testdroid_apk_url)
-    subparser.add_argument("--filename",
-                           help="Specify filename to save Testdroid.apk to in the files directory.")
-    subparser.add_argument("--force",
-                           action="store_true", default=False,
-                           help="Overwrite existing file.")
+    subparser = subparsers.add_parser(
+        "download-testdroid-apk",
+        help="Download Testdroid.apk from %s to files/ then exit." % testdroid_apk_url,
+    )
+    subparser.add_argument(
+        "--filename",
+        help="Specify filename to save Testdroid.apk to in the files directory.",
+    )
+    subparser.add_argument(
+        "--force", action="store_true", default=False, help="Overwrite existing file."
+    )
     subparser.set_defaults(func=download_testdroid_apk)
 
     ### empty-test-zip ###
-    subparser = subparsers.add_parser("empty-test-zip",
-                                      help="Generate empty test zip file in files/ directory then exit.")
-    subparser.add_argument("--filename",
-                           default="empty-test.zip",
-                           help="Specify filename to save in the files directory. "
-                           "Defaults to empty-test.zip.")
+    subparser = subparsers.add_parser(
+        "empty-test-zip",
+        help="Generate empty test zip file in files/ directory then exit.",
+    )
+    subparser.add_argument(
+        "--filename",
+        default="empty-test.zip",
+        help="Specify filename to save in the files directory. "
+        "Defaults to empty-test.zip.",
+    )
     subparser.set_defaults(func=empty_test_zip)
 
     ### test-run-manager ###
-    subparser = subparsers.add_parser('start-test-run-manager',
-                        help='Run the test run manager.')
-    subparser.add_argument("--bitbar-config",
-                           help="Path to Bitbar yaml configuration file.")
-    subparser.add_argument('--wait', dest='wait',
-                           type=int,
-                           default=20,
-                           help='Seconds to wait between checks. Defaults to 20.')
-    subparser.add_argument("--update-bitbar",
-                           action="store_true", default=False,
-                           help="Update the remote bitbar configuration to reflect the config file.")
+    subparser = subparsers.add_parser(
+        "start-test-run-manager", help="Run the test run manager."
+    )
+    subparser.add_argument(
+        "--bitbar-config", help="Path to Bitbar yaml configuration file."
+    )
+    subparser.add_argument(
+        "--wait",
+        dest="wait",
+        type=int,
+        default=20,
+        help="Seconds to wait between checks. Defaults to 20.",
+    )
+    subparser.add_argument(
+        "--update-bitbar",
+        action="store_true",
+        default=False,
+        help="Update the remote bitbar configuration to reflect the config file.",
+    )
     subparser.set_defaults(func=test_run_manager)
 
     ### run-test ###
-    subparser = subparsers.add_parser("run-test",
-                                      help="Run test for a project then exit.")
-    subparser.add_argument("--bitbar-config",
-                           help="Path to Bitbar yaml configuration file.")
-    subparser.add_argument("--update-bitbar",
-                           action="store_true", default=False,
-                           help="Update the remote bitbar configuration to reflect the config file.")
-    subparser.add_argument("--project-name",
-                           required=True,
-                           help="Specify a project name for which to start a test.")
+    subparser = subparsers.add_parser(
+        "run-test", help="Run test for a project then exit."
+    )
+    subparser.add_argument(
+        "--bitbar-config", help="Path to Bitbar yaml configuration file."
+    )
+    subparser.add_argument(
+        "--update-bitbar",
+        action="store_true",
+        default=False,
+        help="Update the remote bitbar configuration to reflect the config file.",
+    )
+    subparser.add_argument(
+        "--project-name",
+        required=True,
+        help="Specify a project name for which to start a test.",
+    )
     subparser.set_defaults(func=run_test)
 
     args = parser.parse_args()
@@ -170,5 +214,6 @@ Terminate Now
 
     args.func(args)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/mozilla_bitbar_devicepool/projects.py
+++ b/mozilla_bitbar_devicepool/projects.py
@@ -27,18 +27,18 @@ def get_projects(**kwargs):
        get_projects(name='mozilla-unittests-p2')
     """
     fields = {
-        'frameworkid': int,
-        'id': int,
-        'name': str,
-        'ostype': str,
-        }
+        "frameworkid": int,
+        "id": int,
+        "name": str,
+        "ostype": str,
+    }
 
     filter = get_filter(fields, **kwargs)
-    response = TESTDROID.get('/api/v2/projects',
-                             payload={'limit': 0, 'filter': filter})
+    response = TESTDROID.get("/api/v2/projects", payload={"limit": 0, "filter": filter})
     # remove the archived projects
-    projects = [project for project in response['data']
-                if project['archiveTime'] is None]
+    projects = [
+        project for project in response["data"] if project["archiveTime"] is None
+    ]
     return projects
 
 
@@ -50,12 +50,13 @@ def get_project(id):
     Examples:
        get_project(1) # Return project with id 1
     """
-    response = TESTDROID.get('/api/v2/projects/{}'.format(id),
-                             payload={'limit': 0, 'filter': filter})
+    response = TESTDROID.get(
+        "/api/v2/projects/{}".format(id), payload={"limit": 0, "filter": filter}
+    )
     return response
 
 
-def create_project(name, project_type='GENERIC'):
+def create_project(name, project_type="GENERIC"):
     """Create a project.
 
     :param name: name for the project.
@@ -70,16 +71,19 @@ def create_project(name, project_type='GENERIC'):
     """
     me = TESTDROID.get_me()
     payload = {
-        'name': name,
-        'type': project_type,
+        "name": name,
+        "type": project_type,
     }
 
-    response = TESTDROID.post(path='/users/{}/projects'.format(me['id']),
-                             payload=payload)
+    response = TESTDROID.post(
+        path="/users/{}/projects".format(me["id"]), payload=payload
+    )
     return response
 
 
-def update_project(id, name, archiving_item_count=365, archiving_strategy='DAYS', description=None):
+def update_project(
+    id, name, archiving_item_count=365, archiving_strategy="DAYS", description=None
+):
     """Update a project.
 
     :param id: integer id of project.
@@ -99,14 +103,15 @@ def update_project(id, name, archiving_item_count=365, archiving_strategy='DAYS'
     """
     me = TESTDROID.get_me()
     payload = {
-        'archivingItemCount': archiving_item_count,
-        'archivingStrategy': archiving_strategy,
-        'description': description,
-        'name': name,
+        "archivingItemCount": archiving_item_count,
+        "archivingStrategy": archiving_strategy,
+        "description": description,
+        "name": name,
     }
 
-    response = TESTDROID.post(path='/users/{}/projects/{}'.format(me['id'], id),
-                             payload=payload)
+    response = TESTDROID.post(
+        path="/users/{}/projects/{}".format(me["id"], id), payload=payload
+    )
     return response
 
 
@@ -125,12 +130,14 @@ def get_project_test_run_config_parameters(id):
     """
     me = TESTDROID.get_me()
     payload = {
-        'limit': 0,
+        "limit": 0,
     }
 
-    response = TESTDROID.get(path='/api/v2/users/{}/projects/{}/config/parameters'.format(me['id'], id),
-                             payload=payload)
-    return response['data']
+    response = TESTDROID.get(
+        path="/api/v2/users/{}/projects/{}/config/parameters".format(me["id"], id),
+        payload=payload,
+    )
+    return response["data"]
 
 
 def add_project_test_run_config_parameter(id, key, value):
@@ -145,12 +152,14 @@ def add_project_test_run_config_parameter(id, key, value):
     """
     me = TESTDROID.get_me()
     payload = {
-        'key': key,
-        'value': value,
+        "key": key,
+        "value": value,
     }
 
-    response = TESTDROID.post(path='/users/{}/projects/{}/config/parameters'.format(me['id'], id),
-                             payload=payload)
+    response = TESTDROID.post(
+        path="/users/{}/projects/{}/config/parameters".format(me["id"], id),
+        payload=payload,
+    )
     return response
 
 
@@ -169,4 +178,8 @@ def delete_project_test_run_config_parameter(id, parameter_id):
     """
     me = TESTDROID.get_me()
 
-    TESTDROID.delete(path='/users/{}/projects/{}/config/parameters/{}'.format(me['id'], id, parameter_id))
+    TESTDROID.delete(
+        path="/users/{}/projects/{}/config/parameters/{}".format(
+            me["id"], id, parameter_id
+        )
+    )

--- a/mozilla_bitbar_devicepool/runs.py
+++ b/mozilla_bitbar_devicepool/runs.py
@@ -63,7 +63,7 @@ def run_test_for_project(project_name):
     for parameter_name in additional_parameters:
         parameter_value = additional_parameters[parameter_name]
         test_configuration["testRunParameters"].append(
-            {"key": parameter_name, "value": parameter_value,}
+            {"key": parameter_name, "value": parameter_value}
         )
 
     return run_test_with_configuration(test_configuration)

--- a/mozilla_bitbar_devicepool/runs.py
+++ b/mozilla_bitbar_devicepool/runs.py
@@ -18,9 +18,10 @@ def run_test_with_configuration(test_configuration):
     """
 
     response = TESTDROID.post(
-        path='runs',
+        path="runs",
         payload=json.dumps(test_configuration),
-        headers={'Content-type': 'application/json', 'Accept': 'application/json'})
+        headers={"Content-type": "application/json", "Accept": "application/json"},
+    )
     return response
 
 
@@ -30,72 +31,74 @@ def run_test_for_project(project_name):
 
     bitbar_test_file = None
     bitbar_application_file = None
-    project_config = CONFIG['projects'][project_name]
+    project_config = CONFIG["projects"][project_name]
 
     test_configuration = {
-        "frameworkId": CACHE['frameworks'][project_config['framework_name']]['id'],
-        "osType": project_config['os_type'],
-        "projectId": CACHE['projects'][project_name]['id'],
-        "scheduler": project_config['scheduler'],
-        "timeout": project_config['timeout'],
-        "deviceGroupId": CACHE['device_groups'][project_config['device_group_name']]['id'],
+        "frameworkId": CACHE["frameworks"][project_config["framework_name"]]["id"],
+        "osType": project_config["os_type"],
+        "projectId": CACHE["projects"][project_name]["id"],
+        "scheduler": project_config["scheduler"],
+        "timeout": project_config["timeout"],
+        "deviceGroupId": CACHE["device_groups"][project_config["device_group_name"]][
+            "id"
+        ],
         "testRunParameters": [],
         "files": [],
     }
 
-    if 'test_file' in project_config:
-        test_file = project_config['test_file']
-        bitbar_test_file = CACHE['files'][test_file]
-        test_configuration['files'].append(
-            {
-                "id": bitbar_test_file["id"],
-                "action": "RUN_TEST"
-            }
+    if "test_file" in project_config:
+        test_file = project_config["test_file"]
+        bitbar_test_file = CACHE["files"][test_file]
+        test_configuration["files"].append(
+            {"id": bitbar_test_file["id"], "action": "RUN_TEST"}
         )
-    if 'application_file' in project_config:
-        application_file = project_config['application_file']
-        bitbar_application_file = CACHE['files'][application_file]
-        test_configuration['files'].append(
-            {
-                "id": bitbar_application_file["id"],
-                "action": "INSTALL"
-            }
+    if "application_file" in project_config:
+        application_file = project_config["application_file"]
+        bitbar_application_file = CACHE["files"][application_file]
+        test_configuration["files"].append(
+            {"id": bitbar_application_file["id"], "action": "INSTALL"}
         )
 
-    additional_parameters = project_config['additional_parameters']
+    additional_parameters = project_config["additional_parameters"]
     for parameter_name in additional_parameters:
         parameter_value = additional_parameters[parameter_name]
-        test_configuration['testRunParameters'].append({
-            'key': parameter_name,
-            'value': parameter_value,
-        })
+        test_configuration["testRunParameters"].append(
+            {"key": parameter_name, "value": parameter_value,}
+        )
 
     return run_test_with_configuration(test_configuration)
+
 
 def get_test_run(project_id, test_run_id):
     data = TESTDROID.get_test_run(project_id, test_run_id)
     return data
 
+
 def get_test_runs(project_id, active=None):
-    test_runs = TESTDROID.get_project_test_runs(project_id)['data']
+    test_runs = TESTDROID.get_project_test_runs(project_id)["data"]
     if active:
-        test_runs = [run for run in test_runs if run['state'] in ('WAITING', 'RUNNING')]
+        test_runs = [run for run in test_runs if run["state"] in ("WAITING", "RUNNING")]
     else:
-        test_runs = [run for run in test_runs if run['state'] not in ('WAITING', 'RUNNING')]
+        test_runs = [
+            run for run in test_runs if run["state"] not in ("WAITING", "RUNNING")
+        ]
     return test_runs
+
 
 def delete_test_run(project_id, test_run_id):
     me = TESTDROID.get_me()
-    path = "/users/%s/projects/%s/runs/%s" %  ( me['id'], project_id, test_run_id )
+    path = "/users/%s/projects/%s/runs/%s" % (me["id"], project_id, test_run_id)
     data = TESTDROID.delete(path=path)
     return data
 
+
 def abort_test_run(project_id, test_run_id):
     return TESTDROID.abort_test_run(project_id, test_run_id)
+
 
 # https://mozilla.testdroid.com/cloud/api/v2/admin/runs?filter=d_endTime_isnull&limit=0
 def get_active_test_runs(**kwargs):
     """Gets active test runs.
     """
-    response = TESTDROID.get('/api/v2/admin/runs?filter=d_endTime_isnull&limit=0')
-    return response['data']
+    response = TESTDROID.get("/api/v2/admin/runs?filter=d_endTime_isnull&limit=0")
+    return response["data"]

--- a/mozilla_bitbar_devicepool/taskcluster.py
+++ b/mozilla_bitbar_devicepool/taskcluster.py
@@ -4,12 +4,13 @@
 
 import requests
 
+
 def get_taskcluster_pending_tasks(provisioner_id, worker_type):
-    taskcluster_queue_url = 'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/pending/%s/%s' % (
-        provisioner_id, worker_type)
+    taskcluster_queue_url = (
+        "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/pending/%s/%s"
+        % (provisioner_id, worker_type)
+    )
     r = requests.get(taskcluster_queue_url)
     if r.ok:
-        return r.json()['pendingTasks']
+        return r.json()["pendingTasks"]
     return 0
-
-

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -13,8 +13,7 @@ import requests
 from mozilla_bitbar_devicepool import configuration, logger
 from mozilla_bitbar_devicepool.device_groups import get_device_group_devices
 from mozilla_bitbar_devicepool.devices import get_offline_devices
-from mozilla_bitbar_devicepool.runs import (get_active_test_runs,
-                                            run_test_for_project)
+from mozilla_bitbar_devicepool.runs import get_active_test_runs, run_test_for_project
 from mozilla_bitbar_devicepool.taskcluster import get_taskcluster_pending_tasks
 
 from testdroid import RequestResponseError
@@ -27,8 +26,8 @@ TESTING = False
 
 CACHE = None
 CONFIG = None
-ARCHIVED_FILE_REGEX = r'FileEntity with id [\d]* does not exist'
-PROJECT_DOES_NOT_EXIST_REGEX = r'Project with id [\d]* does not exist'
+ARCHIVED_FILE_REGEX = r"FileEntity with id [\d]* does not exist"
+PROJECT_DOES_NOT_EXIST_REGEX = r"Project with id [\d]* does not exist"
 
 
 class TestRunManager(object):
@@ -49,131 +48,155 @@ class TestRunManager(object):
         CONFIG = configuration.CONFIG
 
         self.wait = wait
-        self.state = 'RUNNING'
+        self.state = "RUNNING"
 
         signal.signal(signal.SIGUSR2, self.handle_signal)
         signal.signal(signal.SIGINT, self.handle_signal)
 
     def handle_signal(self, signalnum, frame):
-        if self.state != 'RUNNING':
+        if self.state != "RUNNING":
             return
 
         if signalnum == signal.SIGINT or signalnum == signal.SIGUSR2:
-            self.state = 'STOP'
-
+            self.state = "STOP"
 
     def get_bitbar_test_stats(self, project_name, project_config):
-        device_group_name = project_config['device_group_name']
-        device_group = CONFIG['device_groups'][device_group_name]
-        bitbar_device_group = CACHE['device_groups'][device_group_name]
-        stats = CACHE['projects'][project_name]['stats']
-        device_group_count = bitbar_device_group['deviceCount']
+        device_group_name = project_config["device_group_name"]
+        device_group = CONFIG["device_groups"][device_group_name]
+        bitbar_device_group = CACHE["device_groups"][device_group_name]
+        stats = CACHE["projects"][project_name]["stats"]
+        device_group_count = bitbar_device_group["deviceCount"]
 
         offline_devices = []
-        temp_offline_devices = get_offline_devices(device_model=project_config.get('device_model', None))
+        temp_offline_devices = get_offline_devices(
+            device_model=project_config.get("device_model", None)
+        )
         for device_name in temp_offline_devices:
             if device_name in device_group:
                 offline_devices.append(device_name)
-        enabled_devices = get_device_group_devices(bitbar_device_group['id'])
+        enabled_devices = get_device_group_devices(bitbar_device_group["id"])
 
-        stats = CACHE['projects'][project_name]['stats']
-        stats['OFFLINE_DEVICES'] = offline_devices
-        stats['OFFLINE'] = len(offline_devices)
-        stats['DISABLED'] = device_group_count - len(enabled_devices)
+        stats = CACHE["projects"][project_name]["stats"]
+        stats["OFFLINE_DEVICES"] = offline_devices
+        stats["OFFLINE"] = len(offline_devices)
+        stats["DISABLED"] = device_group_count - len(enabled_devices)
 
     def handle_queue(self, project_name, projects_config):
         logger.info("thread starting")
-        stats = CACHE['projects'][project_name]['stats']
-        lock = CACHE['projects'][project_name]['lock']
+        stats = CACHE["projects"][project_name]["stats"]
+        lock = CACHE["projects"][project_name]["lock"]
 
-        while self.state == 'RUNNING':
+        while self.state == "RUNNING":
             project_config = projects_config[project_name]
-            device_group_name = project_config['device_group_name']
-            additional_parameters = project_config['additional_parameters']
-            worker_type = additional_parameters.get('TC_WORKER_TYPE')
+            device_group_name = project_config["device_group_name"]
+            additional_parameters = project_config["additional_parameters"]
+            worker_type = additional_parameters.get("TC_WORKER_TYPE")
 
             with lock:
-                if stats['OFFLINE'] or stats['DISABLED']:
-                    logger.warning('{:10s} DISABLED {} OFFLINE {} {}'.format(
-                        device_group_name,
-                        stats['DISABLED'],
-                        stats['OFFLINE'],
-                        ', '.join(stats['OFFLINE_DEVICES'])))
+                if stats["OFFLINE"] or stats["DISABLED"]:
+                    logger.warning(
+                        "{:10s} DISABLED {} OFFLINE {} {}".format(
+                            device_group_name,
+                            stats["DISABLED"],
+                            stats["OFFLINE"],
+                            ", ".join(stats["OFFLINE_DEVICES"]),
+                        )
+                    )
 
-                taskcluster_provisioner_id = projects_config['defaults']['taskcluster_provisioner_id']
+                taskcluster_provisioner_id = projects_config["defaults"][
+                    "taskcluster_provisioner_id"
+                ]
 
                 # create enough tests to service either the pending tasks or the number of idle
                 # devices which do not already have a waiting test + a small logarithmic fudge
                 # term based on the number of pending tasks (whichever is smaller).
                 try:
-                    pending_tasks = get_taskcluster_pending_tasks(taskcluster_provisioner_id, worker_type)
+                    pending_tasks = get_taskcluster_pending_tasks(
+                        taskcluster_provisioner_id, worker_type
+                    )
                 except requests.ConnectionError as e:
-                    logger.warning("exception raised when calling get_taskcluster_pending_tasks.")
+                    logger.warning(
+                        "exception raised when calling get_taskcluster_pending_tasks."
+                    )
                     logger.warning(e)
                     pending_tasks = 0
                 # warning: only take the log of positive non-zero numbers, or a
                 # "ValueError: math domain error" will be raised
-                jobs_to_start = min(pending_tasks,
-                                    stats['IDLE'] - stats['WAITING'] + 1 + int(math.log10(1 + pending_tasks)))
+                jobs_to_start = min(
+                    pending_tasks,
+                    stats["IDLE"]
+                    - stats["WAITING"]
+                    + 1
+                    + int(math.log10(1 + pending_tasks)),
+                )
                 if jobs_to_start < 0:
                     jobs_to_start = 0
 
-                if stats['RUNNING'] or stats['WAITING']:
+                if stats["RUNNING"] or stats["WAITING"]:
                     logger.info(
-                        'COUNT {} IDLE {} OFFLINE {} DISABLED {} RUNNING {} WAITING {} PENDING {} STARTING {}'.format(
-                            stats['COUNT'],
-                            stats['IDLE'],
-                            stats['OFFLINE'],
-                            stats['DISABLED'],
-                            stats['RUNNING'],
-                            stats['WAITING'],
+                        "COUNT {} IDLE {} OFFLINE {} DISABLED {} RUNNING {} WAITING {} PENDING {} STARTING {}".format(
+                            stats["COUNT"],
+                            stats["IDLE"],
+                            stats["OFFLINE"],
+                            stats["DISABLED"],
+                            stats["RUNNING"],
+                            stats["WAITING"],
                             pending_tasks,
-                            jobs_to_start))
+                            jobs_to_start,
+                        )
+                    )
 
             for _task in range(jobs_to_start):
-                if self.state != 'RUNNING':
+                if self.state != "RUNNING":
                     break
                 try:
                     if TESTING:
-                        logger.info('TESTING MODE: Would be starting test run.')
+                        logger.info("TESTING MODE: Would be starting test run.")
                     else:
                         # if there are no devices assigned, the API will throw an exception
                         # when we try to start, so detect and warn here.
-                        if stats['COUNT'] == 0:
-                            logger.warning("Didn't try to start a job because there are no devices assigned.")
+                        if stats["COUNT"] == 0:
+                            logger.warning(
+                                "Didn't try to start a job because there are no devices assigned."
+                            )
                         else:
                             test_run = run_test_for_project(project_name)
                             # increment so we don't start too many jobs before main thread updates stats
                             with lock:
-                                stats['WAITING'] += 1
+                                stats["WAITING"] += 1
 
-                            logger.info('test run {} started'.format(
-                                test_run['id']))
+                            logger.info("test run {} started".format(test_run["id"]))
                 except RequestResponseError as e:
                     if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, str(e)):
-                        logger.error("Test files have been archived. Exiting so configuration is rerun...")
+                        logger.error(
+                            "Test files have been archived. Exiting so configuration is rerun..."
+                        )
                         logger.error("%s: %s" % (e.__class__.__name__, e))
-                        self.state = 'STOP'
-                    elif e.status_code == 404 and re.search(PROJECT_DOES_NOT_EXIST_REGEX, str(e)):
-                        logger.error("Project does not exist!. Exiting so configuration is rerun...")
+                        self.state = "STOP"
+                    elif e.status_code == 404 and re.search(
+                        PROJECT_DOES_NOT_EXIST_REGEX, str(e)
+                    ):
+                        logger.error(
+                            "Project does not exist!. Exiting so configuration is rerun..."
+                        )
                         logger.error("%s: %s" % (e.__class__.__name__, e))
-                        self.state = 'STOP'
+                        self.state = "STOP"
                     else:
                         logger.error("%s: %s" % (e.__class__.__name__, e))
                 except Exception as e:
                     logger.error(
-                        'Failed to create test run for group %s (%s: %s).'
+                        "Failed to create test run for group %s (%s: %s)."
                         % (device_group_name, e.__class__.__name__, e),
                         exc_info=True,
-                        )
+                    )
 
-            if self.state == 'RUNNING':
+            if self.state == "RUNNING":
                 time.sleep(self.wait)
         logger.info("thread exiting")
 
     def thread_active_jobs(self):
-        while self.state == 'RUNNING':
-            logger.info('getting active runs')
+        while self.state == "RUNNING":
+            logger.info("getting active runs")
             try:
                 self.process_active_runs()
             except requests.exceptions.ConnectionError as e:
@@ -184,8 +207,8 @@ class TestRunManager(object):
             time.sleep(10)
 
     def process_active_runs(self):
-        bitbar_projects = CACHE['projects']
-        bitbar_test_runs = CACHE['test_runs']
+        bitbar_projects = CACHE["projects"]
+        bitbar_test_runs = CACHE["test_runs"]
 
         # init the temporary dict
         accumulation_dict = {}
@@ -201,49 +224,53 @@ class TestRunManager(object):
             return
 
         for item in result:
-            project_name = item['projectName']
+            project_name = item["projectName"]
             # only accumulate for projects in our config
             if project_name in bitbar_projects:
                 accumulation_dict[project_name].append(item)
 
         # replace current values with what we got above
         for project_name in bitbar_projects:
-            stats = CACHE['projects'][project_name]['stats']
-            lock = CACHE['projects'][project_name]['lock']
+            stats = CACHE["projects"][project_name]["stats"]
+            lock = CACHE["projects"][project_name]["lock"]
             with lock:
                 bitbar_test_runs[project_name] = accumulation_dict[project_name]
 
-                stats['RUNNING'] = 0
-                stats['WAITING'] = 0
+                stats["RUNNING"] = 0
+                stats["WAITING"] = 0
                 for test_run in bitbar_test_runs[project_name]:
-                    test_run_state = test_run['state']
+                    test_run_state = test_run["state"]
                     stats[test_run_state] += 1
 
-                stats['IDLE'] = (stats['COUNT'] -
-                                stats['DISABLED'] -
-                                stats['OFFLINE'] -
-                                stats['RUNNING'])
-                if stats['IDLE'] < 0:
-                    stats['IDLE'] = 0
+                stats["IDLE"] = (
+                    stats["COUNT"]
+                    - stats["DISABLED"]
+                    - stats["OFFLINE"]
+                    - stats["RUNNING"]
+                )
+                if stats["IDLE"] < 0:
+                    stats["IDLE"] = 0
 
     def run(self):
-        projects_config = CONFIG['projects']
-        CONFIG['threads'] = []
+        projects_config = CONFIG["projects"]
+        CONFIG["threads"] = []
 
-        active_job_thread = threading.Thread(target=self.thread_active_jobs, name='active_jobs', args=())
-        logger.info('test-run-manager: loading existing runs')
+        active_job_thread = threading.Thread(
+            target=self.thread_active_jobs, name="active_jobs", args=()
+        )
+        logger.info("test-run-manager: loading existing runs")
         active_job_thread.start()
-        CONFIG['threads'].append(active_job_thread)
+        CONFIG["threads"].append(active_job_thread)
         time.sleep(2)
 
         for project_name in projects_config:
-            if project_name == 'defaults':
+            if project_name == "defaults":
                 continue
 
             project_config = projects_config[project_name]
             # device_group_name = project_config['device_group_name']
-            additional_parameters = project_config['additional_parameters']
-            worker_type = additional_parameters.get('TC_WORKER_TYPE')
+            additional_parameters = project_config["additional_parameters"]
+            worker_type = additional_parameters.get("TC_WORKER_TYPE")
 
             if not worker_type:
                 # Only manage projects initiated via Taskcluster.
@@ -255,32 +282,42 @@ class TestRunManager(object):
 
             # multithread handle_queue
             # TODO: should name be project_name or device group name?
-            t1 = threading.Thread(target=self.handle_queue, name=project_name, args=(project_name, projects_config,))
-            CONFIG['threads'].append(t1)
+            t1 = threading.Thread(
+                target=self.handle_queue,
+                name=project_name,
+                args=(project_name, projects_config,),
+            )
+            CONFIG["threads"].append(t1)
             t1.start()
 
         # we need the main thread to keep running so it can handle signals
         # - https://www.g-loaded.eu/2016/11/24/how-to-terminate-running-python-threads-using-signals/
-        while self.state == 'RUNNING':
+        while self.state == "RUNNING":
             waiting_total = 0
             running_total = 0
             time.sleep(60)
-            logger.info('getting stats for all projects')
+            logger.info("getting stats for all projects")
             for project_name in projects_config:
-                if project_name == 'defaults':
+                if project_name == "defaults":
                     continue
-                lock = CACHE['projects'][project_name]['lock']
-                stats = CACHE['projects'][project_name]['stats']
-                waiting_total += stats['WAITING']
-                running_total += stats['RUNNING']
+                lock = CACHE["projects"][project_name]["lock"]
+                stats = CACHE["projects"][project_name]["stats"]
+                waiting_total += stats["WAITING"]
+                running_total += stats["RUNNING"]
                 with lock:
                     try:
-                        self.get_bitbar_test_stats(project_name, projects_config[project_name])
+                        self.get_bitbar_test_stats(
+                            project_name, projects_config[project_name]
+                        )
                     except requests.exceptions.ConnectionError as e:
-                        logger.warning("exception raised when calling get_bitbar_test_stats.")
+                        logger.warning(
+                            "exception raised when calling get_bitbar_test_stats."
+                        )
                         logger.warning(e)
                         # TODO: if we see this a lot, add exponential backoff?
                         time.sleep(15)
                 time.sleep(1)
-            logger.info('WAITING_TOTAL {} RUNNING_TOTAL {}'.format(waiting_total, running_total))
-        logger.info('main thread exiting')
+            logger.info(
+                "WAITING_TOTAL {} RUNNING_TOTAL {}".format(waiting_total, running_total)
+            )
+        logger.info("main thread exiting")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pyflakes
 pytest
 pytest-watch
+pre-commit

--- a/service/bitbar.service
+++ b/service/bitbar.service
@@ -11,4 +11,3 @@ User=bitbar
 
 [Install]
 WantedBy=multi-user.target
-

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setuptools.setup(
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Operating System :: OS Independent",
     ],
-    scripts=['bin/device_group_report'],
+    scripts=["bin/device_group_report"],
 )


### PR DESCRIPTION
Now that we're on Python 3 we can use the Black code formatter (https://github.com/psf/black).

Things done in this change:
- Format all code with Black.
- Setup a pre-commit hook to run black.
  - Runs flake8 (https://github.com/bclary/mozilla-bitbar-devicepool/issues/3) also.
  - Also checks for whitespace and other things.
- travis runs `pre-commit run -a` to check for things not caught at pre-commit stage.
- update docs to mention installing pre-commit hook
