### PR TITLE
add entrypoint

### DIFF
--- a/mozilla_bitbar_devicepool/main.py
+++ b/mozilla_bitbar_devicepool/main.py
@@ -212,7 +212,11 @@ Terminate Now
 
     logger.setLevel(level=args.log_level)
 
-    args.func(args)
+    try:
+        func = args.func
+    except AttributeError:
+        parser.error("too few arguments")
+    func(args)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,9 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     scripts=["bin/device_group_report"],
+    entry_points="""
+    # -*- Entry points: -*-
+    [console_scripts]
+    mbdp = mozilla_bitbar_devicepool.main:main
+    """,
 )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setuptools.setup(
     entry_points="""
     # -*- Entry points: -*-
     [console_scripts]
-    mbdp = mozilla_bitbar_devicepool.main:main
+    mbd = mozilla_bitbar_devicepool.main:main
     """,
 )


### PR DESCRIPTION
Used https://github.com/mozilla/active-data-recipes/blob/07af36490459ebaf7eb131ae046163caafef791c/setup.py as a reference. ADR has since moved on to Poetry (uses a different installation method).

Fixes #4.

```bash
(venv) ➜  mozilla-bitbar-devicepool git:(make_entrypoint) ✗  mbd
usage: mbd [-h] [--files FILES] [--log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG}] {download-testdroid-apk,empty-test-zip,start-test-run-manager,run-test} ...
mbd: error: too few arguments

(venv) ➜  mozilla-bitbar-devicepool git:(make_entrypoint) ✗  mbd --help
usage: mbd [-h] [--files FILES] [--log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG}] {download-testdroid-apk,empty-test-zip,start-test-run-manager,run-test} ...

Mozilla Android Hardware testing at Bitbar.

positional arguments:
  {download-testdroid-apk,empty-test-zip,start-test-run-manager,run-test}
                        Specify one of the positional arguments to select the command to execute.
    download-testdroid-apk
                        Download Testdroid.apk from https://github.com/bitbar/bitbar-samples/blob/master/apps/builds/Testdroid.apk to files/ then exit.
    empty-test-zip      Generate empty test zip file in files/ directory then exit.
    start-test-run-manager
                        Run the test run manager.
    run-test            Run test for a project then exit.

optional arguments:
  -h, --help            show this help message and exit
  --files FILES         Directory where downloaded files are saved. Defaults to /Users/aerickson/git/mozilla-bitbar-devicepool/files
  --log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG}
                        Logging level. Defaults to INFO.

Environment Variables:

The following environment variables must be set prior to attempting to
start the test_run_manager.

TESTDROID_URL
TESTDROID_APIKEY

To get additional help for each positional sub-command, add
--help to the sub-command.

Controlling the test_run_manager via signals:

Stop Now
    kill -USR2 <pid>

    Stop process while leaving test containers running.

Terminate Now
    kill -TERM  <pid>

    Abort any running test containers and exit immediately.
(venv) ➜  mozilla-bitbar-devicepool git:(make_entrypoint) ✗

```