### PR TITLE
prepend project names with API user id

### DIFF
--- a/mozilla_bitbar_devicepool/bitbar/me.py
+++ b/mozilla_bitbar_devicepool/bitbar/me.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from mozilla_bitbar_devicepool import TESTDROID
+
+
+def get_me():
+    """Return information about the current API user.
+
+    Examples:
+       get_me() # Return information about the current API user
+    """
+    response = TESTDROID.get("api/v2/me")
+    return response

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -305,7 +305,7 @@ def configure_projects(update_bitbar=False):
 
         project_config = projects_config[project_name]
 
-        # salt project_name below with user id
+        # prepend project_name with user id
         api_user_id = get_me()["id"]
         salted_project_name = "%s-%s" % (api_user_id, project_name)
 

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -312,10 +312,14 @@ def configure_projects(update_bitbar=False):
             )
         elif len(bitbar_projects) == 1:
             bitbar_project = bitbar_projects[0]
+            logger.info("configure_projects: using project {}".format(bitbar_project))
         else:
             if update_bitbar:
                 bitbar_project = create_project(
                     project_name, project_type=project_config["project_type"]
+                )
+                logger.info(
+                    "configure_projects: created project {}".format(bitbar_project)
                 )
             else:
                 raise Exception(

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -206,10 +206,20 @@ def configure_device_groups(update_bitbar=False):
             )
         elif len(bitbar_device_groups) == 1:
             bitbar_device_group = bitbar_device_groups[0]
+            logger.info(
+                "configure_device_groups: configuring group {} to use {}".format(
+                    device_group_name, bitbar_device_group
+                )
+            )
         else:
             # no such device group. create it.
             if update_bitbar:
                 bitbar_device_group = create_device_group(device_group_name)
+                logger.info(
+                    "configure_device_groups: configuring group {} to use newly created group {}".format(
+                        device_group_name, bitbar_device_group
+                    )
+                )
             else:
                 raise Exception(
                     "device group {} does not exist but can not create.".format(

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -306,7 +306,7 @@ def configure_projects(update_bitbar=False):
         project_config = projects_config[project_name]
 
         # salt project_name below with user id
-        api_user_id = get_me()[id]
+        api_user_id = get_me()["id"]
         salted_project_name = "%s-%s" % (api_user_id, project_name)
 
         bitbar_projects = get_projects(name=salted_project_name)

--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -303,6 +303,7 @@ def configure_projects(update_bitbar=False):
         logger.info("{}: configuring...".format(log_header))
 
         project_config = projects_config[project_name]
+        # TODO: salt project_name below with user id!?!
         bitbar_projects = get_projects(name=project_name)
         if len(bitbar_projects) > 1:
             raise DuplicateProjectException(


### PR DESCRIPTION
Whenever we switch accounts running devicepool we've had to share the project with the new owner in the Bitbar UI.

Try to avoid that completely by having each user create their own projects.

This code prepends the user id to the project name that is used at bitbar.