### PR TITLE
use 20201110T135924 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20200804T101109
+      DOCKER_IMAGE_VERSION: 20201110T135924
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
Includes fixes for s7g and unrooted testing (https://github.com/bclary/mozilla-bitbar-docker/pull/50).

see #139 for test details